### PR TITLE
feature: Add frontend for connections page

### DIFF
--- a/frontend/src/components/ViewAccounts/AccountTile.jsx
+++ b/frontend/src/components/ViewAccounts/AccountTile.jsx
@@ -1,0 +1,63 @@
+import { AccountType } from "../../utils/globalUtils"
+import { ConnectPageContext } from "../../pages/ConnectPage"
+import { useContext } from "react"
+import { redirectToAccountProfile } from "./utils"
+
+
+
+
+export default function AccountTile(accountInformation) {
+    const { selectedAccountType, navigate } = useContext(ConnectPageContext)
+    const selectedHiringClassName = accountInformation.currentlyHiring
+        ? "hiring"
+        : "not-hiring"
+
+    const accountDisplay =
+        selectedAccountType == AccountType.TEAM ? (
+            <div
+                className="account"
+                key={accountInformation.accountId}
+                onClick={redirectToAccountProfile(
+                    accountInformation,
+                    AccountType.TEAM,
+                    navigate
+                )}
+            >
+                <div className="view-profile-picture"></div>
+                <div className="view-details">
+                    <h2>{accountInformation.name}</h2>
+                    <div className="account-information">
+                        <h3>{`${accountInformation.description} • ${accountInformation.location}`}</h3>
+                        <div className="account-information-hiring">
+                            <div className={selectedHiringClassName}></div>
+                            <h4 className={selectedHiringClassName}>
+                                {accountInformation.currentlyHiring
+                                    ? "Hiring"
+                                    : "No Open Positions"}
+                            </h4>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        ) : (
+            <div
+                className="account"
+                key={accountInformation.accountId}
+                onClick={redirectToAccountProfile(
+                    accountInformation,
+                    AccountType.PLAYER,
+                    navigate
+                )}
+            >
+                <div className="view-profile-picture"></div>
+                <div className="view-details">
+                    <h2>{`${accountInformation.firstName} ${accountInformation.lastName}`}</h2>
+                    <div className="account-information">
+                        <h3>{accountInformation.bio}</h3>
+                    </div>
+                </div>
+            </div>
+        )
+
+    return accountDisplay
+}

--- a/frontend/src/components/ViewAccounts/PageSelector.css
+++ b/frontend/src/components/ViewAccounts/PageSelector.css
@@ -1,0 +1,32 @@
+.page-selector {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 16px;
+  }
+
+  .page-btn {
+    padding: 8px 16px;
+    border: 1px solid #ccc;
+    background-color: white;
+    color: #333;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+  }
+
+  .page-btn.active:hover {
+    background-color: #f5f5f5;
+  }
+
+  .page-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .page-info {
+    font-size: 14px;
+    color: #666;
+    margin: 0 8px;
+  }

--- a/frontend/src/components/ViewAccounts/PageSelector.jsx
+++ b/frontend/src/components/ViewAccounts/PageSelector.jsx
@@ -1,0 +1,27 @@
+import "./PageSelector.css"
+
+export default function PageSelector({ page, setPage, totalPages }) {
+	return (
+		<div className="page-selector">
+			<button
+				className={`page-btn ${page === 1 ? "" : "active"}`}
+				onClick={() => setPage(page - 1)}
+				disabled={page === 1}
+			>
+				Previous
+			</button>
+
+			<span className="page-info">
+				Page {page} of {totalPages}
+			</span>
+
+			<button
+				className={`page-btn ${page < totalPages ? "active" : ""}`}
+				onClick={() => setPage(page + 1)}
+				disabled={page >= totalPages}
+			>
+				Next
+			</button>
+		</div>
+	)
+}

--- a/frontend/src/components/ViewAccounts/utils.jsx
+++ b/frontend/src/components/ViewAccounts/utils.jsx
@@ -1,0 +1,28 @@
+import { BASEURL } from "../../utils/globalUtils"
+import AccountTile from "./AccountTile"
+
+export function redirectToAccountProfile(accountInformation, accountType, navigate) {
+    return function () {
+        const navigationPath = accountType == AccountType.TEAM ? "teams" : "profiles"
+        navigate(`/${navigationPath}/${accountInformation.accountId}`)
+    }
+}
+
+export async function loadPage(selectedAccountType, page, setTotalPages, setDisplay) {
+    try {
+        const response = await fetch(
+            `${BASEURL}/collection/${selectedAccountType}s/?page=${page}`
+        )
+        const pageData = await response.json()
+        if (!response.ok) throw new Error()
+
+        setTotalPages(pageData.totalPages)
+        setDisplay(
+            pageData.data.map((account) =>
+                AccountTile(account)
+            )
+        )
+    } catch (error) {
+        console.error(`Error while retrieving page ${page} data:`, error)
+    }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,6 +6,7 @@ import { AccountType } from "./utils/globalUtils.js"
 import App from "./App.jsx"
 import ProfilePage from "./pages/ProfilePage.jsx"
 import PrivateRoute from "./utils/PrivateRoute.jsx"
+import ConnectPage from "./pages/ConnectPage.jsx"
 
 const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID
 
@@ -30,6 +31,10 @@ createRoot(document.getElementById("root")).render(
 								page={<ProfilePage accountType={AccountType.TEAM} />}
 							/>
 						}
+					/>
+					<Route
+						path="/connect"
+						element={<PrivateRoute page={<ConnectPage />} />}
 					/>
 				</Routes>
 			</BrowserRouter>

--- a/frontend/src/pages/ConnectPage.jsx
+++ b/frontend/src/pages/ConnectPage.jsx
@@ -1,0 +1,75 @@
+import { useNavigate } from "react-router-dom"
+import { useState, useEffect, createContext } from "react"
+import { AccountType } from "../utils/globalUtils"
+import Navbar from "../components/Navbar/Navbar"
+import PageSelector from "../components/ViewAccounts/PageSelector"
+import { loadPage } from "../components/ViewAccounts/utils"
+export const ConnectPageContext = createContext()
+
+
+
+export default function ConnectPage() {
+	const initialPage = 1
+	const [display, setDisplay] = useState([])
+	const [page, setPage] = useState(initialPage)
+	const [totalPages, setTotalPages] = useState(initialPage)
+	const [selectedAccountType, setSelectedAccountType] = useState(AccountType.TEAM)
+	const navigate = useNavigate()
+
+	const viewPlayersButtonClassName = `view-players-btn ${
+		selectedAccountType === AccountType.PLAYER ? "selected" : ""
+	}`
+	const viewTeamsButtonClassName = `view-teams-btn ${
+		selectedAccountType === AccountType.TEAM ? "selected" : ""
+	}`
+
+	useEffect(() => {
+		loadPage(selectedAccountType, page, setTotalPages, setDisplay)
+	}, [page, selectedAccountType])
+
+	return (
+		<>
+			<ConnectPageContext.Provider
+				value={{
+					display,
+					setDisplay,
+					navigate,
+					selectedAccountType,
+					setSelectedAccountType,
+				}}
+			>
+				<Navbar />
+				<div className="view-page">
+					<div className="header">
+						<div className="view-players">
+							<button
+								className={viewPlayersButtonClassName}
+								onClick={() => {
+									setPage(initialPage)
+									setSelectedAccountType(AccountType.PLAYER)
+								}}
+							>
+								View Players
+							</button>
+						</div>
+						<div className="view-teams">
+							<button
+								className={viewTeamsButtonClassName}
+								onClick={() => {
+									setPage(initialPage)
+									setSelectedAccountType(AccountType.TEAM)
+								}}
+							>
+								View Teams
+							</button>
+						</div>
+					</div>
+					<div className="page-content">
+						<div className="accounts">{display}</div>
+					</div>
+				</div>
+				<PageSelector page={page} setPage={setPage} totalPages={totalPages} />
+			</ConnectPageContext.Provider>
+		</>
+	)
+}


### PR DESCRIPTION
## Description
This PR lays the groundwork for the connections page, a feature that will enable users to browse other teams and players. This PR focuses on setting up the page's wireframe and essential buttons, including the necessary buttons for user interaction. Future PRs will implement CSS styling, backend functionality to allow accounts to be retrieved from the database, and implementing pagination to efficiently fetch and display accounts in batches.

## Screenshots
_Page wireframe_
<img width="1728" alt="Screenshot 2025-07-08 at 7 37 05 PM" src="https://github.com/user-attachments/assets/413a9eb9-06d3-4825-aae9-50b48f6525b8" />

_Full page_
<img width="1728" alt="Screenshot 2025-07-08 at 7 23 38 PM" src="https://github.com/user-attachments/assets/9098cd07-74cb-4eac-9d33-f50c302d20df" />
