### PR TITLE
feature: Feature team5

### DIFF
--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -6,6 +6,7 @@ const {
 	verifyTeamSignupInformation,
 	formatClientAccountInformation,
 	AccountType,
+	dataPagination,
 } = require("./utils")
 const express = require("express")
 const cors = require("cors")
@@ -44,6 +45,24 @@ server.get("/profiles/:profileId", async (req, res, next) => {
 		return res.status(200).json(playerData)
 	} catch (error) {
 		next(error)
+	}
+})
+
+server.get("/collection/players", async (req, res, next) => {
+	try {
+		const pageData = await dataPagination(prisma, AccountType.PLAYER, req.query)
+		return res.json(pageData)
+	} catch (err) {
+		next(err)
+	}
+})
+
+server.get("/collection/teams", async (req, res, next) => {
+	try {
+		const pageData = await dataPagination(prisma, AccountType.TEAM, req.query)
+		return res.json(pageData)
+	} catch (err) {
+		next(err)
 	}
 })
 

--- a/backend/api/utils.js
+++ b/backend/api/utils.js
@@ -5,6 +5,7 @@ import dotenv from "dotenv"
 
 dotenv.config()
 const TOKEN_SECRET = process.env.TOKEN_SECRET
+const PAGE_SIZE = 10
 
 export function verifyPlayerSignupInformation(requestBody) {
 	const isDataValid =
@@ -67,5 +68,25 @@ export async function verifySessionToken(token) {
 		return decoded
 	} catch (err) {
 		return null
+	}
+}
+
+export async function dataPagination(prisma, accountType, query) {
+	const initialPage = 1
+	let page = initialPage
+	if (query != null && query.page != null && !isNaN(parseInt(query.page))) {
+		page = parseInt(query.page)
+	}
+
+	const accountsInPage = await prisma[accountType].findMany({
+		skip: (page - 1) * PAGE_SIZE,
+		take: PAGE_SIZE,
+	})
+
+	const totalPages = Math.ceil((await prisma[accountType].count()) / PAGE_SIZE)
+	return {
+		data: accountsInPage,
+		totalPages: totalPages,
+		currentPage: page,
 	}
 }

--- a/backend/prisma/migrations/20250707034614_db_dev/migration.sql
+++ b/backend/prisma/migrations/20250707034614_db_dev/migration.sql
@@ -1,3 +1,0 @@
--- AlterTable
-ALTER TABLE "Team" ADD COLUMN     "description" TEXT,
-ADD COLUMN     "overview" TEXT;

--- a/backend/prisma/migrations/20250709113618_dev_2/migration.sql
+++ b/backend/prisma/migrations/20250709113618_dev_2/migration.sql
@@ -1,6 +1,9 @@
 -- CreateEnum
 CREATE TYPE "AccountType" AS ENUM ('player', 'team');
 
+-- CreateEnum
+CREATE TYPE "ApplicationStatus" AS ENUM ('pending', 'accepted', 'rejected');
+
 -- CreateTable
 CREATE TABLE "Account" (
     "id" SERIAL NOT NULL,
@@ -33,9 +36,22 @@ CREATE TABLE "Team" (
     "location" TEXT NOT NULL,
     "currentlyHiring" BOOLEAN NOT NULL,
     "yearEstablished" TEXT NOT NULL,
+    "description" TEXT,
+    "overview" TEXT,
     "accountId" INTEGER NOT NULL,
 
     CONSTRAINT "Team_pkey" PRIMARY KEY ("teamId")
+);
+
+-- CreateTable
+CREATE TABLE "Application" (
+    "applicationId" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "playerAccountId" INTEGER NOT NULL,
+    "teamAccountId" INTEGER NOT NULL,
+    "status" "ApplicationStatus" NOT NULL DEFAULT 'pending',
+
+    CONSTRAINT "Application_pkey" PRIMARY KEY ("applicationId")
 );
 
 -- CreateIndex
@@ -47,8 +63,17 @@ CREATE UNIQUE INDEX "Player_accountId_key" ON "Player"("accountId");
 -- CreateIndex
 CREATE UNIQUE INDEX "Team_accountId_key" ON "Team"("accountId");
 
+-- CreateIndex
+CREATE UNIQUE INDEX "Application_playerAccountId_teamAccountId_key" ON "Application"("playerAccountId", "teamAccountId");
+
 -- AddForeignKey
 ALTER TABLE "Player" ADD CONSTRAINT "Player_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "Team" ADD CONSTRAINT "Team_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Application" ADD CONSTRAINT "Application_playerAccountId_fkey" FOREIGN KEY ("playerAccountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Application" ADD CONSTRAINT "Application_teamAccountId_fkey" FOREIGN KEY ("teamAccountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -13,6 +13,12 @@ enum AccountType {
   team
 }
 
+enum ApplicationStatus {
+  pending
+  accepted
+  rejected
+}
+
 model Account {
   id Int @id @default(autoincrement())
   createdAt  DateTime @default(now())
@@ -20,6 +26,8 @@ model Account {
   email String @unique
   player Player?
   team  Team?
+  playerApplications Application[] @relation("PlayerApplications")
+  teamApplications Application[] @relation("TeamApplications")
 }
 
 model Player {
@@ -45,4 +53,16 @@ model Team {
   overview   String?
   accountId  Int @unique
   account     Account @relation(fields: [accountId], references: [id])
+}
+
+model Application {
+  applicationId Int @id @default(autoincrement())
+  createdAt  DateTime @default(now())
+  playerAccountId  Int
+  teamAccountId     Int
+  status     ApplicationStatus @default(pending)
+  playerAccount     Account @relation(fields: [playerAccountId], references: [id], name: "PlayerApplications")
+  teamAccount      Account @relation(fields: [teamAccountId], references: [id], name: "TeamApplications")
+
+  @@unique([playerAccountId, teamAccountId])
 }

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,33 +1,87 @@
-//This file will be used to seed the database with initial data for testing purposes.
+//This file is used to seed the database with initial data for testing purposes. Will be removed in production.
 
 const { PrismaClient } = require("../generated/prisma")
 const prisma = new PrismaClient()
 
-const player = {
+const generatedTeamInfo = {
+	name: "Unlimited Range Gaming",
+	location: "US",
+	description: "FPS focused e-sports Team",
+	overview:
+		"We are a team of FPS players looking to expand our reach and grow our community.",
+	yearEstablished: "2022",
+	currentlyHiring: true,
+}
+
+const generatedPlayerInfo = {
 	firstName: "Billy",
 	lastName: "Bob",
 	yearsOfExperience: "0",
 	location: "US",
 	willingToRelocate: false,
+	bio: "#1 ranked player in the US | FPS certified | Full-time",
+	about: "Hello!, I'm a FPS player looking to expand my reach and grow my community. I'm currently looking for a team to join and help me achieve my goals.",
 }
-const accounts = [{ id: 1, player: player, team: null }]
 
 async function main() {
-    await prisma.account.create({
-        data: {
-            accountType: "player",
+	await prisma.account.create({
+		data: {
+			accountType: "player",
 			email: "billybob@bob.com",
-            player: {
-                create: {
-                    firstName: "Billy",
-                    lastName: "Bob",
-                    yearsOfExperience: "0",
-                    location: "US",
-                    willingToRelocate: false,
-                }
-            }
-        }
-    })
+			player: {
+				create: generatedPlayerInfo,
+			},
+		},
+	})
+
+	for (let i = 0; i < 10; i++) {
+		await prisma.account.create({
+			data: {
+				accountType: "player",
+				email: `player${i}@gmail.com`,
+				player: {
+					create: {
+						firstName: `Player`,
+						lastName: `${i}`,
+						yearsOfExperience: "0",
+						location: "US",
+						willingToRelocate: false,
+						bio: `#${i} ranked player on valorant`,
+						about: "This is my about section!",
+					},
+				},
+			},
+		})
+	}
+
+	await prisma.account.create({
+		data: {
+			accountType: "team",
+			email: "URG@gmail.com",
+			team: {
+				create: generatedTeamInfo,
+			},
+		},
+	})
+
+	for (let i = 0; i < 10; i++) {
+		await prisma.account.create({
+			data: {
+				accountType: "team",
+				email: `team${i}@gmail.com`,
+				team: {
+					create: {
+						name: `Team${i}`,
+						location: "Asia",
+						description: `This is team ${i}'s description`,
+						overview: `This is team ${i}'s overview`,
+						yearEstablished: "2022",
+						currentlyHiring: true,
+					},
+				},
+			},
+		})
+	}
 }
 
 main()

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,9 @@
-import { AccountType, BASEURL, TOKEN_STORAGE_KEY, ACCOUNT_INFORMATION_KEY } from "./utils/globalUtils"
+import {
+	AccountType,
+	BASEURL,
+	TOKEN_STORAGE_KEY,
+	ACCOUNT_INFORMATION_KEY,
+} from "./utils/globalUtils"
 export const LOGIN_FAILURE = "LOGIN_FAILURE"
 
 export async function onLoginAttempt(email) {
@@ -7,14 +12,15 @@ export async function onLoginAttempt(email) {
 
 		if (response.ok === true) {
 			const accountData = await response.json()
+
 			localStorage.setItem(TOKEN_STORAGE_KEY, accountData.token)
 			localStorage.setItem(ACCOUNT_INFORMATION_KEY, JSON.stringify(accountData))
 			return accountData
 		} else {
 			return LOGIN_FAILURE
 		}
-	} catch (error) {
-		console.error("Error while trying to login:", error)
+	} catch {
+		console.error(`Error while trying to login with ${email}, redirecting to signup`)
 	}
 }
 

--- a/frontend/src/components/Profile/TeamProfile.jsx
+++ b/frontend/src/components/Profile/TeamProfile.jsx
@@ -10,7 +10,9 @@ export default function TeamProfile({ isLoading, accountData }) {
 		return <h1>Loading...</h1>
 	}
 
-	const [description, setDescription] = useState(accountData.description || defaultProfileInfo)
+	const [description, setDescription] = useState(
+		accountData.description || defaultProfileInfo
+	)
 	const [overview, setOverview] = useState(accountData.overview || defaultProfileInfo)
 
 	return (
@@ -27,7 +29,9 @@ export default function TeamProfile({ isLoading, accountData }) {
 					<div className="profile-info">
 						<h1 className="profile-name">{`${accountData.name}`}</h1>
 						<div className="profile-title">
-							<p className="profile-title-text">{`${description}`}</p>
+							<p className="profile-title-text">{`${
+								description || defaultProfileInfo
+							}`}</p>
 						</div>
 						<p className="profile-location">📍 {accountData.location}</p>
 					</div>

--- a/frontend/src/components/ViewAccounts/AccountTile.jsx
+++ b/frontend/src/components/ViewAccounts/AccountTile.jsx
@@ -2,62 +2,62 @@ import { AccountType } from "../../utils/globalUtils"
 import { ConnectPageContext } from "../../pages/ConnectPage"
 import { useContext } from "react"
 import { redirectToAccountProfile } from "./utils"
+const defaultProfileInfo = ""
 
+export default function AccountTile({ accountInformation }) {
+	const { selectedAccountType, navigate } = useContext(ConnectPageContext)
+	const selectedHiringClassName = accountInformation.currentlyHiring
+		? "hiring"
+		: "not-hiring"
 
+	const accountDisplay =
+		selectedAccountType == AccountType.TEAM ? (
+			<div
+				className="account"
+				key={accountInformation.accountId}
+				onClick={redirectToAccountProfile(
+					accountInformation,
+					AccountType.TEAM,
+					navigate
+				)}
+			>
+				<div className="view-profile-picture"></div>
+				<div className="view-details">
+					<h2>{accountInformation.name}</h2>
+					<div className="account-information">
+						<h3>{`${accountInformation.description || defaultProfileInfo} • ${
+							accountInformation.location
+						}`}</h3>
+						<div className="account-information-hiring">
+							<div className={selectedHiringClassName}></div>
+							<h4 className={selectedHiringClassName}>
+								{accountInformation.currentlyHiring
+									? "Hiring"
+									: "No Open Positions"}
+							</h4>
+						</div>
+					</div>
+				</div>
+			</div>
+		) : (
+			<div
+				className="account"
+				key={accountInformation.accountId}
+				onClick={redirectToAccountProfile(
+					accountInformation,
+					AccountType.PLAYER,
+					navigate
+				)}
+			>
+				<div className="view-profile-picture"></div>
+				<div className="view-details">
+					<h2>{`${accountInformation.firstName} ${accountInformation.lastName}`}</h2>
+					<div className="account-information">
+						<h3>{accountInformation.bio}</h3>
+					</div>
+				</div>
+			</div>
+		)
 
-
-export default function AccountTile(accountInformation) {
-    const { selectedAccountType, navigate } = useContext(ConnectPageContext)
-    const selectedHiringClassName = accountInformation.currentlyHiring
-        ? "hiring"
-        : "not-hiring"
-
-    const accountDisplay =
-        selectedAccountType == AccountType.TEAM ? (
-            <div
-                className="account"
-                key={accountInformation.accountId}
-                onClick={redirectToAccountProfile(
-                    accountInformation,
-                    AccountType.TEAM,
-                    navigate
-                )}
-            >
-                <div className="view-profile-picture"></div>
-                <div className="view-details">
-                    <h2>{accountInformation.name}</h2>
-                    <div className="account-information">
-                        <h3>{`${accountInformation.description} • ${accountInformation.location}`}</h3>
-                        <div className="account-information-hiring">
-                            <div className={selectedHiringClassName}></div>
-                            <h4 className={selectedHiringClassName}>
-                                {accountInformation.currentlyHiring
-                                    ? "Hiring"
-                                    : "No Open Positions"}
-                            </h4>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        ) : (
-            <div
-                className="account"
-                key={accountInformation.accountId}
-                onClick={redirectToAccountProfile(
-                    accountInformation,
-                    AccountType.PLAYER,
-                    navigate
-                )}
-            >
-                <div className="view-profile-picture"></div>
-                <div className="view-details">
-                    <h2>{`${accountInformation.firstName} ${accountInformation.lastName}`}</h2>
-                    <div className="account-information">
-                        <h3>{accountInformation.bio}</h3>
-                    </div>
-                </div>
-            </div>
-        )
-
-    return accountDisplay
+	return accountDisplay
 }

--- a/frontend/src/components/ViewAccounts/AccountTile.jsx
+++ b/frontend/src/components/ViewAccounts/AccountTile.jsx
@@ -58,6 +58,5 @@ export default function AccountTile({ accountInformation }) {
 				</div>
 			</div>
 		)
-
 	return accountDisplay
 }

--- a/frontend/src/components/ViewAccounts/ConnectPage.css
+++ b/frontend/src/components/ViewAccounts/ConnectPage.css
@@ -1,0 +1,225 @@
+.view-page {
+    margin-top: 15px;
+}
+
+.header {
+    display: flex;
+    justify-content: center;
+    gap: 50px;
+    padding: 16px 24px;
+    background-color: #ffffff;
+    border-bottom: 1px solid #e0e0e0;
+    box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.view-players-btn,
+.view-teams-btn {
+    padding: 8px 160px;
+    border: 1px solid #0073b1;
+    border-radius: 24px;
+    background-color: transparent;
+    color: #0073b1;
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.view-players-btn.selected,
+.view-teams-btn.selected {
+    background-color: #0073b1;
+    color: white;
+}
+
+.view-players-btn:hover,
+.view-teams-btn:hover {
+    box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.08);
+}
+
+.page-content {
+    display: flex;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 24px;
+    gap: 24px;
+}
+
+.sidebar {
+    width: 240px;
+    background-color: #ffffff;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 16px;
+    height: fit-content;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+}
+
+.sidebar-options {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.sidebar-options-btn {
+    padding: 12px 16px;
+    border: none;
+    background-color: transparent;
+    color: #666666;
+    font-size: 14px;
+    font-weight: 500;
+    text-align: left;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.sidebar-options-btn:hover {
+    background-color: #f3f2ef;
+    color: #0073b1;
+}
+
+.accounts {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.account {
+    background-color: #ffffff;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 15px 15px 15px 15px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+    transition: box-shadow 0.2s ease;
+    display: flex;
+    flex-direction: row;
+    gap: 30px;
+    cursor: pointer;
+}
+
+.view-details {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.account:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
+}
+
+.view-profile-picture {
+    width: 60px;
+    position: relative;
+    margin: 0px;
+    top: 0px;
+    left: 0px;
+    height: 60px;
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    background: #666666;
+    border: 4px solid #ffffff;
+}
+
+.account h2 {
+    margin: 0 0 0px 0;
+    font-size: 24px;
+    font-weight: 600;
+    color: #0073b1;
+    line-height: 1.3;
+}
+
+.account-information {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    margin-top: 10px;
+    width: 100%;
+}
+
+.account-information h3 {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 400;
+    color: #666666;
+    line-height: 1.4;
+}
+
+.account-information-hiring {
+    display: flex;
+    flex-direction: row;
+    align-items: end;
+    margin-top: 5px;
+}
+
+.account-information-hiring div {
+    display: flex;
+    border-radius: 100%;
+    width: 10px;
+    height: 10px;
+    margin-right: 12px;
+    margin-bottom: 4px;
+}
+
+.hiring {
+    box-shadow: 0 0 10px 2px rgba(0, 255, 0, 0.6);
+    background-color: rgba(0, 255, 0, 0.8);
+}
+
+.hiring + h4 {
+    color: rgb(0, 137, 0);
+    box-shadow: 0 0 0px 0px transparent;
+    background-color: transparent;
+}
+
+.not-hiring  {
+    box-shadow: 0 0 10px 2px rgba(255, 0, 0, 0.6);
+    background-color: rgba(255, 0, 0, 0.8);
+}
+
+.not-hiring + h4 {
+    color: rgb(255, 0, 0);
+    box-shadow: 0 0 0px 0px transparent;
+    background-color: transparent;
+}
+
+.account-information-hiring h4 {
+    display: flex;
+    margin: 0px;
+    margin-top: 5px;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.4;
+}
+
+.account-information button {
+    padding: 8px 20px;
+    background-color: #0073b1;
+    color: white;
+    border: none;
+    border-radius: 24px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.post-information button:hover {
+    background-color: #005885;
+}
+
+@media (max-width: 768px) {
+    .page-content {
+        flex-direction: column;
+        padding: 16px;
+    }
+
+    .sidebar {
+        width: 95%;
+    }
+
+    .header {
+        flex-direction: column;
+        gap: 5px;
+    }
+}

--- a/frontend/src/components/ViewAccounts/utils.jsx
+++ b/frontend/src/components/ViewAccounts/utils.jsx
@@ -2,27 +2,25 @@ import { BASEURL } from "../../utils/globalUtils"
 import AccountTile from "./AccountTile"
 
 export function redirectToAccountProfile(accountInformation, accountType, navigate) {
-    return function () {
-        const navigationPath = accountType == AccountType.TEAM ? "teams" : "profiles"
-        navigate(`/${navigationPath}/${accountInformation.accountId}`)
-    }
+	return function () {
+		const navigationPath = accountType == AccountType.TEAM ? "teams" : "profiles"
+		navigate(`/${navigationPath}/${accountInformation.accountId}`)
+	}
 }
 
-export async function loadPage(selectedAccountType, page, setTotalPages, setDisplay) {
-    try {
-        const response = await fetch(
-            `${BASEURL}/collection/${selectedAccountType}s/?page=${page}`
-        )
-        const pageData = await response.json()
-        if (!response.ok) throw new Error()
+export async function loadPage(accountType, page, setTotalPages, setDisplay) {
+	try {
+		const response = await fetch(
+			`${BASEURL}/collection/${accountType}s/?page=${page}`
+		)
+		const pageData = await response.json()
+		if (!response.ok) throw new Error()
 
-        setTotalPages(pageData.totalPages)
-        setDisplay(
-            pageData.data.map((account) =>
-                AccountTile(account)
-            )
-        )
-    } catch (error) {
-        console.error(`Error while retrieving page ${page} data:`, error)
-    }
+		setTotalPages(pageData.totalPages)
+		setDisplay(
+			pageData.data.map((account) => <AccountTile accountInformation={account} />)
+		)
+	} catch (error) {
+		console.error(`Error while retrieving page ${page} data:`, error)
+	}
 }

--- a/frontend/src/pages/ConnectPage.jsx
+++ b/frontend/src/pages/ConnectPage.jsx
@@ -1,12 +1,11 @@
 import { useNavigate } from "react-router-dom"
 import { useState, useEffect, createContext } from "react"
 import { AccountType } from "../utils/globalUtils"
+import { loadPage } from "../components/ViewAccounts/utils"
 import Navbar from "../components/Navbar/Navbar"
 import PageSelector from "../components/ViewAccounts/PageSelector"
-import { loadPage } from "../components/ViewAccounts/utils"
+import "../components/ViewAccounts/ConnectPage.css"
 export const ConnectPageContext = createContext()
-
-
 
 export default function ConnectPage() {
 	const initialPage = 1


### PR DESCRIPTION
## Description
This commit adds features to the Connections page which allows the user to view other team and player accounts. Users are able to switch between team and player views, enabling them to view all players or teams on the website. Pagination is used to only display up to 10 accounts at a time. Users can scroll through multiple pages using the page selector at the bottom of the page. The Prisma schema has also been updated to reflect the most relevant data models.

## Milestones
- Users can browse and view other teams' and players' profiles.

## Resources
[Prisma pagination documentation](https://www.prisma.io/docs/orm/prisma-client/queries/pagination)

## Test Plan
The seed.js file has been updated to create 11 player accounts and 11 team accounts, providing a comprehensive test dataset for verifying the pagination feature's functionality across different scenarios.

## Screenshots
_View teams page 1_
<img width="1728" alt="Screenshot 2025-07-09 at 4 45 23 AM" src="https://github.com/user-attachments/assets/41b6f7ce-116b-47de-b07a-0ebf57966654" />

_View teams page 2_
<img width="1728" alt="Screenshot 2025-07-09 at 4 45 31 AM" src="https://github.com/user-attachments/assets/02d398ea-b2c0-4e65-b92f-6ba89c85d3dc" />

_View players page 1_
<img width="1728" alt="Screenshot 2025-07-09 at 4 45 41 AM" src="https://github.com/user-attachments/assets/5a148eab-0d7a-4421-a08e-b583d01f5ecf" />