### PR TITLE
feature: Add player applications to teams

### DIFF
--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -94,12 +94,44 @@ server.get("/api/login/", async (req, res, next) => {
 server.get("/account/applications/:accountId", async (req, res, next) => {
 	try {
 		const accountId = parseInt(req.params.accountId)
-		const data = await prisma.application.findMany({
+		const userApplications = await prisma.application.findMany({
 			where: {
 				OR: [{ playerAccountId: accountId }, { teamAccountId: accountId }],
 			},
 		})
-		return res.status(200).json(data)
+		return res.status(200).json(userApplications)
+	} catch (error) {
+		next(error)
+	}
+})
+
+server.post("/account/application", async (req, res, next) => {
+	try {
+		const playerApplicationToTeam = await prisma.application.findUnique({
+			where: {
+				playerAccountId_teamAccountId: {
+					playerAccountId: req.body.playerAccountId,
+					teamAccountId: req.body.teamAccountId,
+				},
+			},
+		})
+
+		if (playerApplicationToTeam != null) {
+			res.status(400).json({
+				error: "Cannot create application, player has already applied",
+			})
+			return
+		}
+
+		const createdApplication = await prisma.application.create({
+			data: {
+				playerAccountId: req.body.playerAccountId,
+				teamAccountId: req.body.teamAccountId,
+				status: req.body.status,
+			},
+		})
+
+		return res.status(200).json(createdApplication)
 	} catch (error) {
 		next(error)
 	}

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -4,7 +4,9 @@ import {
 	TOKEN_STORAGE_KEY,
 	ACCOUNT_INFORMATION_KEY,
 } from "./utils/globalUtils"
+
 export const LOGIN_FAILURE = "LOGIN_FAILURE"
+const PENDING_APPLICATION_STATUS = "pending"
 
 export async function onLoginAttempt(email) {
 	try {

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -3,12 +3,24 @@ import { AccountType, getAccountDataFromLocalStorage } from "../../utils/globalU
 import { ACCOUNT_INFORMATION_KEY } from "../../utils/globalUtils"
 import { Link, useNavigate } from "react-router-dom"
 
+function navigateToUserProfile(navigate) {
+	const accountData = getAccountDataFromLocalStorage()
+	if (accountData === null) {
+		navigate("/")
+		return
+	}
+
+	const navigationPath =
+		accountData.accountType === AccountType.PLAYER ? "profiles" : "teams"
+	navigate(`/${navigationPath}/${accountData.id}`)
+}
+
 export default function Navbar() {
 	return (
 		<div className="navbar">
 			<div className="navbar-contents">
 				<div className="tournament">
-					<TournamentButton />
+					<TournamentsButton />
 				</div>
 				<div className="apply">
 					<ApplyButton />
@@ -22,18 +34,6 @@ export default function Navbar() {
 			</div>
 		</div>
 	)
-}
-
-function navigateToUserProfile(navigate) {
-	const accountData = getAccountDataFromLocalStorage()
-	if (accountData === null) {
-		navigate("/")
-		return
-	}
-
-	const navigationPath =
-		accountData.accountType === AccountType.PLAYER ? "profiles" : "teams"
-	navigate(`/${navigationPath}/${accountData.id}`)
 }
 
 function ConnectButton() {
@@ -60,7 +60,7 @@ function ProfileButton() {
 	)
 }
 
-function TournamentButton() {
+function TournamentsButton() {
 	return (
 		<button className="tournament-btn">
 			<h3>Tournaments</h3>
@@ -69,8 +69,18 @@ function TournamentButton() {
 }
 
 function ApplyButton() {
+	const navigate = useNavigate()
+	const accountData = getAccountDataFromLocalStorage()
+	if (accountData === null) {
+		navigate("/")
+		return
+	}
+
 	return (
-		<button className="apply-btn">
+		<button
+			onClick={() => navigate(`/apply/${accountData.id}`)}
+			className="apply-btn"
+		>
 			<h3>Apply</h3>
 		</button>
 	)

--- a/frontend/src/components/Profile/ApplyButton.jsx
+++ b/frontend/src/components/Profile/ApplyButton.jsx
@@ -1,0 +1,18 @@
+import { createTeamApplication } from "../../api"
+import { useNavigate } from "react-router-dom"
+
+async function onApplyButtonClick(navigate, playerAccountId, teamAccountId) {
+	await createTeamApplication(playerAccountId, teamAccountId)
+	navigate(`/apply/${playerAccountId}`)
+}
+
+export default function ApplyButton({ playerAccountId, teamAccountId }) {
+	const navigate = useNavigate()
+	return (
+		<button
+			onClick={() => onApplyButtonClick(navigate, playerAccountId, teamAccountId)}
+		>
+			Apply
+		</button>
+	)
+}

--- a/frontend/src/components/Profile/TeamProfile.jsx
+++ b/frontend/src/components/Profile/TeamProfile.jsx
@@ -1,8 +1,9 @@
-import { AboutEditButton, BioEditButton } from "./EditButton"
 import { createContext, useState } from "react"
+import { getAccountDataFromLocalStorage, AccountType } from "../../utils/globalUtils"
+import ApplyButton from "./ApplyButton"
 import "./ProfilePage.css"
-const defaultProfileInfo = ""
 
+const defaultProfileInfo = ""
 export const TeamProfileContext = createContext()
 
 export default function TeamProfile({ isLoading, accountData }) {
@@ -14,6 +15,7 @@ export default function TeamProfile({ isLoading, accountData }) {
 		accountData.description || defaultProfileInfo
 	)
 	const [overview, setOverview] = useState(accountData.overview || defaultProfileInfo)
+	const localStorageAccountData = getAccountDataFromLocalStorage()
 
 	return (
 		<TeamProfileContext.Provider value={{ setDescription, setOverview }}>
@@ -39,7 +41,14 @@ export default function TeamProfile({ isLoading, accountData }) {
 						<div>
 							<button>Home</button>
 							<button>Roster</button>
-							<button>Apply</button>
+							{localStorageAccountData &&
+								localStorageAccountData.accountType != AccountType.TEAM &&
+								localStorageAccountData.id !== accountData.accountId && (
+									<ApplyButton
+										playerAccountId={localStorageAccountData.id}
+										teamAccountId={accountData.accountId}
+									/>
+								)}
 						</div>
 					</div>
 				</div>

--- a/frontend/src/components/TeamApplications/Applications.jsx
+++ b/frontend/src/components/TeamApplications/Applications.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react"
 import { getApplicationsFromAccountId } from "../../api"
-import { Sidebar, ApplicationTile } from "./Utils"
+import { Sidebar, createApplicationTile } from "./Utils"
 import "./ApplyPage.css"
 
 function EmptyApplicationsDisplay() {
@@ -19,7 +19,7 @@ async function loadApplications(accountId, setApplicationsDisplay) {
         return
     }
 
-	const newApplicationsDisplay = applications.map((applicationData) => <ApplicationTile applicationData={applicationData}/>)
+	const newApplicationsDisplay = applications.map((applicationData) => createApplicationTile(applicationData))
     setApplicationsDisplay(newApplicationsDisplay)
 }
 

--- a/frontend/src/components/TeamApplications/Utils.jsx
+++ b/frontend/src/components/TeamApplications/Utils.jsx
@@ -1,7 +1,7 @@
 import { getProfileData } from "../../api"
 import { AccountType } from "../../utils/globalUtils"
 
-export async function ApplicationTile({ applicationData }) {
+export async function createApplicationTile(applicationData) {
 	const profileInformation = await getProfileData(AccountType.TEAM, applicationData.teamAccountId)
 
 	return (


### PR DESCRIPTION
## Description
This PR introduces the ability for player accounts to apply to teams. Additionally, players can now view the teams they have applied to. This feature is exclusive to player accounts, team accounts are not able to apply to other team accounts. A future PR will add pagination for viewing teams the player has applied to.

## Screenshots
_View after applying to a team_
<img width="1728" alt="Screenshot 2025-07-09 at 10 18 46 AM" src="https://github.com/user-attachments/assets/a6613f7b-c064-48cf-b526-0eec01d57cc8" />
_View after applying to multiple teams_
<img width="1728" alt="Screenshot 2025-07-09 at 10 19 37 AM" src="https://github.com/user-attachments/assets/524f9345-7ab3-4e5b-9689-83015eeb30ef" />

## Video preview
[video](https://pxl.cl/7Gsrc)