### PR TITLE
fix: Replace localStorage for sessionStorage

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,7 @@
 import {
 	AccountType,
 	BASEURL,
-	TOKEN_STORAGE_KEY,
+	TOKEN_SESSION_KEY,
 	ACCOUNT_INFORMATION_KEY,
 } from "./utils/globalUtils"
 
@@ -15,8 +15,8 @@ export async function onLoginAttempt(email) {
 		if (response.ok === true) {
 			const accountData = await response.json()
 
-			localStorage.setItem(TOKEN_STORAGE_KEY, accountData.token)
-			localStorage.setItem(ACCOUNT_INFORMATION_KEY, JSON.stringify(accountData))
+			sessionStorage.setItem(TOKEN_SESSION_KEY, accountData.token)
+			sessionStorage.setItem(ACCOUNT_INFORMATION_KEY, JSON.stringify(accountData))
 			return accountData
 		} else {
 			return LOGIN_FAILURE
@@ -57,7 +57,7 @@ export async function createTeamApplication(playerAccountId, teamAccountId) {
 			body: JSON.stringify({
 				teamAccountId: teamAccountId,
 				playerAccountId: playerAccountId,
-				status: PENDING_APPLICATION_STATUS
+				status: PENDING_APPLICATION_STATUS,
 			}),
 		})
 		const data = await response.json()

--- a/frontend/src/components/LoginForm/LoginForm.jsx
+++ b/frontend/src/components/LoginForm/LoginForm.jsx
@@ -9,7 +9,7 @@ import "./LoginForm.css"
 
 async function onLoginSuccess(setSignupModalVisible, credentialResponse, navigate) {
 	const token = jwtDecode(credentialResponse.credential)
-	localStorage.setItem(GOOGLE_EMAIL_KEY, token.email)
+	sessionStorage.setItem(GOOGLE_EMAIL_KEY, token.email)
 
 	const loginResult = await onLoginAttempt(token.email)
 	if (loginResult === LOGIN_FAILURE) {

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -10,7 +10,7 @@ export default function Navbar() {
 	const [accountData, setAccountData] = useState(null)
 
 	useEffect(() => {
-		const accountData = getAccountDataFromLocalStorage()
+		const accountData = getAccountDataFromSessionStorage()
 		if (accountData === null) {
 			navigate("/")
 			return

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -1,10 +1,10 @@
 import "./Navbar.css"
-import { AccountType, getAccountDataFromLocalStorage } from "../../utils/globalUtils"
+import { AccountType, getAccountDataFromSessionStorage } from "../../utils/globalUtils"
 import { ACCOUNT_INFORMATION_KEY } from "../../utils/globalUtils"
 import { Link, useNavigate } from "react-router-dom"
 
 function navigateToUserProfile(navigate) {
-	const accountData = getAccountDataFromLocalStorage()
+	const accountData = getAccountDataFromSessionStorage()
 	if (accountData === null) {
 		navigate("/")
 		return
@@ -70,7 +70,7 @@ function TournamentsButton() {
 
 function ApplyButton() {
 	const navigate = useNavigate()
-	const accountData = getAccountDataFromLocalStorage()
+	const accountData = getAccountDataFromSessionStorage()
 	if (accountData === null) {
 		navigate("/")
 		return

--- a/frontend/src/components/Profile/EditButtonUtils.jsx
+++ b/frontend/src/components/Profile/EditButtonUtils.jsx
@@ -1,8 +1,8 @@
-import { TOKEN_STORAGE_KEY, BASEURL, AccountType } from "../../utils/globalUtils"
+import { TOKEN_SESSION_KEY, BASEURL, AccountType } from "../../utils/globalUtils"
 import { LOGIN_FAILURE } from "../../api"
 
 export async function modalSubmitHelper(textValue, detailType, accountType, id) {
-	const token = localStorage.getItem(TOKEN_STORAGE_KEY)
+	const token = sessionStorage.getItem(TOKEN_SESSION_KEY)
 	if (token == null) {
 		return
 	}

--- a/frontend/src/components/Profile/TeamProfile.jsx
+++ b/frontend/src/components/Profile/TeamProfile.jsx
@@ -1,5 +1,5 @@
 import { createContext, useState } from "react"
-import { getAccountDataFromLocalStorage, AccountType } from "../../utils/globalUtils"
+import { getAccountDataFromSessionStorage, AccountType } from "../../utils/globalUtils"
 import ApplyButton from "./ApplyButton"
 import "./ProfilePage.css"
 
@@ -15,7 +15,7 @@ export default function TeamProfile({ isLoading, accountData }) {
 		accountData.description || defaultProfileInfo
 	)
 	const [overview, setOverview] = useState(accountData.overview || defaultProfileInfo)
-	const localStorageAccountData = getAccountDataFromLocalStorage()
+	const sessionStorageAccountData = getAccountDataFromSessionStorage()
 
 	return (
 		<TeamProfileContext.Provider value={{ setDescription, setOverview }}>
@@ -41,11 +41,13 @@ export default function TeamProfile({ isLoading, accountData }) {
 						<div>
 							<button>Home</button>
 							<button>Roster</button>
-							{localStorageAccountData &&
-								localStorageAccountData.accountType != AccountType.TEAM &&
-								localStorageAccountData.id !== accountData.accountId && (
+							{sessionStorageAccountData &&
+								sessionStorageAccountData.accountType !=
+									AccountType.TEAM &&
+								sessionStorageAccountData.id !==
+									accountData.accountId && (
 									<ApplyButton
-										playerAccountId={localStorageAccountData.id}
+										playerAccountId={sessionStorageAccountData.id}
 										teamAccountId={accountData.accountId}
 									/>
 								)}

--- a/frontend/src/components/SignupModal/SignupForm.jsx
+++ b/frontend/src/components/SignupModal/SignupForm.jsx
@@ -5,8 +5,8 @@ import {
 	AccountType,
 	GOOGLE_EMAIL_KEY,
 	BASEURL,
-	TOKEN_STORAGE_KEY,
-	ACCOUNT_INFORMATION_KEY
+	TOKEN_SESSION_KEY,
+	ACCOUNT_INFORMATION_KEY,
 } from "../../utils/globalUtils.js"
 import PlayerSignup from "./PlayerSignup"
 import TeamSignup from "./TeamSignup"
@@ -17,7 +17,7 @@ const optionalSignupInformation = ["lastName"]
 async function onFormValid(formData, selectedAccountType, navigate) {
 	const body = {
 		...formData[selectedAccountType],
-		email: localStorage.getItem(GOOGLE_EMAIL_KEY),
+		email: sessionStorage.getItem(GOOGLE_EMAIL_KEY),
 	}
 
 	try {
@@ -31,8 +31,8 @@ async function onFormValid(formData, selectedAccountType, navigate) {
 		const accountData = await response.json()
 		if (!response.ok) throw new Error()
 
-		localStorage.setItem(TOKEN_STORAGE_KEY, accountData.token)
-		localStorage.setItem(ACCOUNT_INFORMATION_KEY, JSON.stringify(accountData))
+		sessionStorage.setItem(TOKEN_SESSION_KEY, accountData.token)
+		sessionStorage.setItem(ACCOUNT_INFORMATION_KEY, JSON.stringify(accountData))
 		const navigationURL =
 			accountData.accountType === AccountType.PLAYER ? "/profiles/" : "/teams/"
 

--- a/frontend/src/pages/ApplyPage.jsx
+++ b/frontend/src/pages/ApplyPage.jsx
@@ -1,15 +1,15 @@
-import { getAccountDataFromLocalStorage } from "../utils/globalUtils"
+import { getAccountDataFromSessionStorage } from "../utils/globalUtils"
 import { useParams } from "react-router-dom"
 import { useEffect, useState } from "react"
 import { Applications } from "../components/TeamApplications/Applications"
 import Navbar from "../components/Navbar/Navbar"
 
 async function validateUserPermissionToViewPage(setAccountData, id) {
-    const accountData = getAccountDataFromLocalStorage()
-    if (accountData === null) {
-        return false
-    }
-    if (accountData.id.toString() === id.toString()) {
+	const accountData = getAccountDataFromSessionStorage()
+	if (accountData === null) {
+		return false
+	}
+	if (accountData.id.toString() === id.toString()) {
 		setAccountData(accountData)
 		return true
 	}

--- a/frontend/src/utils/globalUtils.js
+++ b/frontend/src/utils/globalUtils.js
@@ -1,5 +1,5 @@
 export const GOOGLE_EMAIL_KEY = "GoogleEmail"
-export const TOKEN_STORAGE_KEY = "Token"
+export const TOKEN_SESSION_KEY = "Token"
 export const ACCOUNT_INFORMATION_KEY = "AccountInformation"
 export const BASEURL = import.meta.env.VITE_RENDER_LINK || "http://localhost:3000"
 export const AccountType = Object.freeze({
@@ -28,13 +28,13 @@ export const LOCATION_OPTIONS = [
 
 export function isLoggedIn() {
 	return (
-		localStorage.getItem(ACCOUNT_INFORMATION_KEY) !== null &&
-		localStorage.getItem(TOKEN_STORAGE_KEY) !== null
+		sessionStorage.getItem(ACCOUNT_INFORMATION_KEY) !== null &&
+		sessionStorage.getItem(TOKEN_SESSION_KEY) !== null
 	)
 }
 
-export function getAccountDataFromLocalStorage() {
-	const accountInformation = localStorage.getItem(ACCOUNT_INFORMATION_KEY)
+export function getAccountDataFromSessionStorage() {
+	const accountInformation = sessionStorage.getItem(ACCOUNT_INFORMATION_KEY)
 	const parsedAccountInformation = accountInformation && JSON.parse(accountInformation)
 
 	if (


### PR DESCRIPTION
## Description
This commit goes through every file and swaps localStorage for sessionStorage. The purpose of this is to allow for multiple users to be logged in on the same local device from different tabs. The original decision to use localStorage was made after feedback left on a PR. SessionStorage will allow for easier testing.


This commit replaces all instances of `localStorage` with `sessionStorage` to enable multiple users to log in from different tabs on the same local device. The original decision to use localStorage to store certain user data was made after feedback left on a PR [here](https://github.com/XiWorl/PlayerLink/pull/6#discussion_r2172872286).

Note that the primary difference between sessionStorage and localStorage is that sessionStorage data is cleared when the browser tab or window is closed, whereas localStorage data persists even after the browser is closed.

## Resources
[Session storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
[Local storage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)

