### PR TITLE
fix: Resolve profile editing bug and profile loading page issues

### DIFF
--- a/backend/api/server.js
+++ b/backend/api/server.js
@@ -235,7 +235,7 @@ server.patch("/api/profiles/edit", async (req, res, next) => {
 
 		const updatedAccount = await editPlayerProfileInformation(
 			prisma,
-			authorization.id,
+			verifiedAuthorization.id,
 			req.body
 		)
 		if (!updatedAccount) {

--- a/frontend/src/components/Profile/EditButton.jsx
+++ b/frontend/src/components/Profile/EditButton.jsx
@@ -3,7 +3,6 @@ import { CustomizableModal } from "../CustomizableModal/CustomizableModal"
 import { ModalTextBox } from "../CustomizableModal/utils"
 import { modalSubmitHelper } from "./EditButtonUtils"
 import { useState, useContext } from "react"
-import { useParams } from "react-router-dom"
 import { UserProfileContext } from "./UserProfile"
 export const TypeOfEditButton = {
 	BIO: "bio",
@@ -11,8 +10,7 @@ export const TypeOfEditButton = {
 }
 
 function onAboutModalSubmitButtonClicked(textValue) {
-	const { id } = useParams()
-	const { setAbout } = useContext(UserProfileContext)
+	const { setAbout, id } = useContext(UserProfileContext)
 	return async function () {
 		const updatedAboutObject = await modalSubmitHelper(
 			textValue,
@@ -24,9 +22,9 @@ function onAboutModalSubmitButtonClicked(textValue) {
 			setAbout(updatedAboutObject.updatedValue)
 	}
 }
+
 function onBioModalSubmitButtonClicked(textValue) {
-	const { id } = useParams()
-	const { setBio } = useContext(UserProfileContext)
+	const { setBio, id } = useContext(UserProfileContext)
 	return async function () {
 		const updatedBioObject = await modalSubmitHelper(
 			textValue,
@@ -69,15 +67,9 @@ export function EditButtonTemplate({ detailType, onSubmitButtonClicked }) {
 	)
 }
 
-function verifyUserOwnsProfile(id) {
-	const accountData = getAccountDataFromSessionStorage()
-	if (!accountData || id != getAccountDataFromSessionStorage().id) return false
-	return true
-}
-
 export function AboutEditButton() {
-	const { id } = useParams()
-	if (!verifyUserOwnsProfile(id)) return null
+	const { loggedInAccountData } = useContext(UserProfileContext)
+	if (!loggedInAccountData) return null
 
 	return (
 		<EditButtonTemplate
@@ -88,8 +80,8 @@ export function AboutEditButton() {
 }
 
 export function BioEditButton() {
-	const { id } = useParams()
-	if (!verifyUserOwnsProfile(id)) return null
+	const { loggedInAccountData } = useContext(UserProfileContext)
+	if (!loggedInAccountData) return null
 
 	return (
 		<EditButtonTemplate

--- a/frontend/src/components/Profile/EditButton.jsx
+++ b/frontend/src/components/Profile/EditButton.jsx
@@ -68,8 +68,8 @@ export function EditButtonTemplate({ detailType, onSubmitButtonClicked }) {
 }
 
 export function AboutEditButton() {
-	const { loggedInAccountData } = useContext(UserProfileContext)
-	if (!loggedInAccountData) return null
+	const { loggedInAccountData, id } = useContext(UserProfileContext)
+	if (!loggedInAccountData || loggedInAccountData.id != id) return null
 
 	return (
 		<EditButtonTemplate
@@ -80,8 +80,8 @@ export function AboutEditButton() {
 }
 
 export function BioEditButton() {
-	const { loggedInAccountData } = useContext(UserProfileContext)
-	if (!loggedInAccountData) return null
+	const { loggedInAccountData, id } = useContext(UserProfileContext)
+	if (!loggedInAccountData || loggedInAccountData.id != id) return null
 
 	return (
 		<EditButtonTemplate

--- a/frontend/src/components/Profile/EditButton.jsx
+++ b/frontend/src/components/Profile/EditButton.jsx
@@ -1,4 +1,4 @@
-import { AccountType } from "../../utils/globalUtils"
+import { AccountType, getAccountDataFromSessionStorage } from "../../utils/globalUtils"
 import { CustomizableModal } from "../CustomizableModal/CustomizableModal"
 import { ModalTextBox } from "../CustomizableModal/utils"
 import { modalSubmitHelper } from "./EditButtonUtils"
@@ -69,7 +69,16 @@ export function EditButtonTemplate({ detailType, onSubmitButtonClicked }) {
 	)
 }
 
+function verifyUserOwnsProfile(id) {
+	const accountData = getAccountDataFromSessionStorage()
+	if (!accountData || id != getAccountDataFromSessionStorage().id) return false
+	return true
+}
+
 export function AboutEditButton() {
+	const { id } = useParams()
+	if (!verifyUserOwnsProfile(id)) return null
+
 	return (
 		<EditButtonTemplate
 			detailType={TypeOfEditButton.ABOUT}
@@ -79,6 +88,9 @@ export function AboutEditButton() {
 }
 
 export function BioEditButton() {
+	const { id } = useParams()
+	if (!verifyUserOwnsProfile(id)) return null
+
 	return (
 		<EditButtonTemplate
 			detailType={TypeOfEditButton.BIO}

--- a/frontend/src/components/Profile/TeamProfile.jsx
+++ b/frontend/src/components/Profile/TeamProfile.jsx
@@ -6,8 +6,9 @@ import "./ProfilePage.css"
 const defaultProfileInfo = ""
 export const TeamProfileContext = createContext()
 
-export default function TeamProfile({ isLoading, accountData }) {
-	if (isLoading) {
+export default function TeamProfile({ isLoading, accountData, setIsLoading }) {
+	if (isLoading || accountData.playerId != null) {
+		setIsLoading(true)
 		return <h1>Loading...</h1>
 	}
 

--- a/frontend/src/components/Profile/UserProfile.jsx
+++ b/frontend/src/components/Profile/UserProfile.jsx
@@ -1,5 +1,5 @@
 import { AboutEditButton, BioEditButton } from "./EditButton"
-import { getAccountDataFromSessionStorage } from "../../utils/globalUtils"
+import { getAccountDataFromSessionStorage, AccountType } from "../../utils/globalUtils"
 import { useParams } from "react-router-dom"
 import { createContext, useState, useEffect } from "react"
 import "./ProfilePage.css"
@@ -7,8 +7,9 @@ const defaultProfileInfo = ""
 
 export const UserProfileContext = createContext()
 
-export default function UserProfile({ isLoading, accountData }) {
-	if (isLoading) {
+export default function UserProfile({ isLoading, accountData, setIsLoading }) {
+	if (isLoading || accountData.teamId != null) {
+		setIsLoading(true)
 		return <h1>Loading...</h1>
 	}
 

--- a/frontend/src/components/Profile/UserProfile.jsx
+++ b/frontend/src/components/Profile/UserProfile.jsx
@@ -1,5 +1,7 @@
 import { AboutEditButton, BioEditButton } from "./EditButton"
-import { createContext, useState } from "react"
+import { getAccountDataFromSessionStorage } from "../../utils/globalUtils"
+import { useParams } from "react-router-dom"
+import { createContext, useState, useEffect } from "react"
 import "./ProfilePage.css"
 const defaultProfileInfo = ""
 
@@ -10,11 +12,19 @@ export default function UserProfile({ isLoading, accountData }) {
 		return <h1>Loading...</h1>
 	}
 
+	useEffect(() => {
+		setLoggedInAccountData(getAccountDataFromSessionStorage())
+	}, [])
+
 	const [bio, setBio] = useState(accountData.bio || defaultProfileInfo)
 	const [about, setAbout] = useState(accountData.about || defaultProfileInfo)
+	const [loggedInAccountData, setLoggedInAccountData] = useState(null)
+	const { id } = useParams()
 
 	return (
-		<UserProfileContext.Provider value={{ setAbout, setBio }}>
+		<UserProfileContext.Provider
+			value={{ setAbout, setBio, loggedInAccountData, id }}
+		>
 			<div className="profile-page">
 				<div className="profile-banner">
 					<div className="profile-picture">

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -7,6 +7,9 @@ import Navbar from "../components/Navbar/Navbar"
 import UserProfile from "../components/Profile/UserProfile"
 import "../components/Profile/ProfilePage.css"
 
+const INITIAL_DISPLAY_ID = -1
+let currentAccountIdDisplayed = INITIAL_DISPLAY_ID
+
 async function displayProfileData(accountType, id, setAccountData, setIsLoading) {
 	const data = await getProfileData(accountType, id)
 	setAccountData(data)
@@ -18,9 +21,15 @@ export default function ProfilePage({ accountType }) {
 	const [isLoading, setIsLoading] = useState(true)
 	const { id } = useParams()
 
+	if (id != currentAccountIdDisplayed) {
+		setIsLoading(true)
+		displayProfileData(accountType, id, setAccountData, setIsLoading)
+	}
+
 	useEffect(() => {
 		displayProfileData(accountType, id, setAccountData, setIsLoading)
 	}, [])
+	currentAccountIdDisplayed = id
 
 	return accountType == AccountType.PLAYER ? (
 		<>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -7,9 +7,6 @@ import Navbar from "../components/Navbar/Navbar"
 import UserProfile from "../components/Profile/UserProfile"
 import "../components/Profile/ProfilePage.css"
 
-const INITIAL_ACCOUNT_DISPLAY_ID = -1
-let currentAccountIdDisplayed = INITIAL_ACCOUNT_DISPLAY_ID
-
 async function displayProfileData(accountType, id, setAccountData, setIsLoading) {
 	const data = await getProfileData(accountType, id)
 	setAccountData(data)
@@ -21,25 +18,28 @@ export default function ProfilePage({ accountType }) {
 	const [isLoading, setIsLoading] = useState(true)
 	const { id } = useParams()
 
-	if (id != currentAccountIdDisplayed) {
+	useEffect(() => {
 		setIsLoading(true)
 		displayProfileData(accountType, id, setAccountData, setIsLoading)
-	}
-	currentAccountIdDisplayed = id
-
-	useEffect(() => {
-		displayProfileData(accountType, id, setAccountData, setIsLoading)
-	}, [])
+	}, [id])
 
 	return accountType == AccountType.PLAYER ? (
 		<>
 			<Navbar />
-			<UserProfile isLoading={isLoading} accountData={accountData} />
+			<UserProfile
+				isLoading={isLoading}
+				accountData={accountData}
+				setIsLoading={setIsLoading}
+			/>
 		</>
 	) : (
 		<>
 			<Navbar />
-			<TeamProfile isLoading={isLoading} accountData={accountData} />
+			<TeamProfile
+				isLoading={isLoading}
+				accountData={accountData}
+				setIsLoading={setIsLoading}
+			/>
 		</>
 	)
 }

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -7,8 +7,8 @@ import Navbar from "../components/Navbar/Navbar"
 import UserProfile from "../components/Profile/UserProfile"
 import "../components/Profile/ProfilePage.css"
 
-const INITIAL_DISPLAY_ID = -1
-let currentAccountIdDisplayed = INITIAL_DISPLAY_ID
+const INITIAL_ACCOUNT_DISPLAY_ID = -1
+let currentAccountIdDisplayed = INITIAL_ACCOUNT_DISPLAY_ID
 
 async function displayProfileData(accountType, id, setAccountData, setIsLoading) {
 	const data = await getProfileData(accountType, id)

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -25,11 +25,11 @@ export default function ProfilePage({ accountType }) {
 		setIsLoading(true)
 		displayProfileData(accountType, id, setAccountData, setIsLoading)
 	}
+	currentAccountIdDisplayed = id
 
 	useEffect(() => {
 		displayProfileData(accountType, id, setAccountData, setIsLoading)
 	}, [])
-	currentAccountIdDisplayed = id
 
 	return accountType == AccountType.PLAYER ? (
 		<>


### PR DESCRIPTION
## Description
This PR addresses two bugs related to profile management. Firstly, it ensures that the edit button for the profile's bio and description is only visible when a user is viewing their own profile, preventing unauthorized access from editing another user's profile. Secondly, it resolves a bug that caused profiles to fail loading when navigating from one profile page to another. This bug was fixed by implementing a re-rendering mechanism that updates the page after switching to a new profile.

## Video preview
https://github.com/user-attachments/assets/c60f6413-4979-4571-a6c3-8906c8d0e924

