### PR TITLE
feature: Enable team accounts to edit profile descriptions

### DIFF
--- a/backend/api/utils.js
+++ b/backend/api/utils.js
@@ -1,5 +1,10 @@
 import jwt from "jsonwebtoken"
-export const EditType = { ABOUT: "about", BIO: "bio", OVERVIEW: "overview" }
+export const EditType = {
+	ABOUT: "about",
+	BIO: "bio",
+	OVERVIEW: "overview",
+	DESCRIPTION: "description",
+}
 export const AccountType = { PLAYER: "player", TEAM: "team" }
 import dotenv from "dotenv"
 
@@ -39,17 +44,16 @@ export function formatClientAccountInformation(accountInformation, jwtToken) {
 	return clientResponseInformation
 }
 
-export async function editPlayerProfileInformation(prisma, loggedInUserId, body) {
+export async function editProfileInformation(prisma, loggedInUserId, body) {
 	if (body.editType == null || body.value == null || EditType[body.editType] == null) {
-		return false
+		return null
 	}
-	if (body.accountId == null || loggedInUserId != body.accountId) {
-		return false
+	if (body.accountId == null || loggedInUserId != body.accountId || !body.accountType) {
+		return null
 	}
 
-	const accountType = "player"
 	const sectionOfProfileToEdit = EditType[body.editType]
-	const updatedPlayerData = await prisma[accountType].update({
+	const updatedPlayerData = await prisma[body.accountType].update({
 		where: { accountId: loggedInUserId },
 		data: {
 			[sectionOfProfileToEdit]: body.value,
@@ -70,6 +74,20 @@ export async function verifySessionToken(token) {
 	} catch (err) {
 		return null
 	}
+}
+
+export async function verifyUserAuthorization(authorizationHeader) {
+	const token = authorizationHeader.replace("Bearer ", "")
+	const verifiedAuthorization = await verifySessionToken(token)
+
+	if (
+		verifiedAuthorization == null ||
+		!verifiedAuthorization ||
+		!verifiedAuthorization.id
+	) {
+		return null
+	}
+	return verifiedAuthorization
 }
 
 export async function dataPagination(prisma, accountType, query) {

--- a/frontend/src/components/CustomizableModal/utils.jsx
+++ b/frontend/src/components/CustomizableModal/utils.jsx
@@ -15,7 +15,13 @@ export function ModalTextBox({ setIsModalOpen, onSubmitButtonClicked }) {
 				onChange={(event) => onTextFieldValueChange(event, setText)}
 			></textarea>
 			<div className="modal-buttons">
-				<button className="submit-btn" onClick={onSubmitButtonClicked(text)}>
+				<button
+					className="submit-btn"
+					onClick={() => {
+						onSubmitButtonClicked(text)
+						setIsModalOpen(false)
+					}}
+				>
 					Submit
 				</button>
 				<button className="cancel-btn" onClick={() => setIsModalOpen(false)}>

--- a/frontend/src/components/CustomizableModal/utils.jsx
+++ b/frontend/src/components/CustomizableModal/utils.jsx
@@ -4,11 +4,6 @@ function onTextFieldValueChange(event, setText) {
 	setText(event.target.value)
 }
 
-function closeModal(onSubmitButtonClicked, text, setIsModalOpen) {
-	onSubmitButtonClicked(text)
-	setIsModalOpen(false)
-}
-
 export function ModalTextBox({ setIsModalOpen, onSubmitButtonClicked }) {
 	const [text, setText] = useState("")
 

--- a/frontend/src/components/CustomizableModal/utils.jsx
+++ b/frontend/src/components/CustomizableModal/utils.jsx
@@ -4,6 +4,11 @@ function onTextFieldValueChange(event, setText) {
 	setText(event.target.value)
 }
 
+function closeModal(onSubmitButtonClicked, text, setIsModalOpen) {
+	onSubmitButtonClicked(text)
+	setIsModalOpen(false)
+}
+
 export function ModalTextBox({ setIsModalOpen, onSubmitButtonClicked }) {
 	const [text, setText] = useState("")
 

--- a/frontend/src/components/Profile/EditButton.jsx
+++ b/frontend/src/components/Profile/EditButton.jsx
@@ -1,47 +1,16 @@
-import { AccountType, getAccountDataFromSessionStorage } from "../../utils/globalUtils"
+import { getAccountDataFromSessionStorage } from "../../utils/globalUtils"
 import { CustomizableModal } from "../CustomizableModal/CustomizableModal"
 import { ModalTextBox } from "../CustomizableModal/utils"
-import { modalSubmitHelper } from "./EditButtonUtils"
-import { useState, useContext } from "react"
-import { useParams } from "react-router-dom"
-import { UserProfileContext } from "./UserProfile"
+import { useState } from "react"
 export const TypeOfEditButton = {
 	BIO: "bio",
 	ABOUT: "about",
+	OVERVIEW: "overview",
+	DESCRIPTION: "description",
 }
 
-function onAboutModalSubmitButtonClicked(textValue) {
-	const { id } = useParams()
-	const { setAbout } = useContext(UserProfileContext)
-	return async function () {
-		const updatedAboutObject = await modalSubmitHelper(
-			textValue,
-			TypeOfEditButton.ABOUT,
-			AccountType.PLAYER,
-			id
-		)
-		if (updatedAboutObject.updatedValue != null)
-			setAbout(updatedAboutObject.updatedValue)
-	}
-}
-function onBioModalSubmitButtonClicked(textValue) {
-	const { id } = useParams()
-	const { setBio } = useContext(UserProfileContext)
-	return async function () {
-		const updatedBioObject = await modalSubmitHelper(
-			textValue,
-			TypeOfEditButton.BIO,
-			AccountType.PLAYER,
-			id
-		)
-		if (updatedBioObject.updatedValue != null) setBio(updatedBioObject.updatedValue)
-	}
-}
-
-export function EditButtonTemplate({ detailType, onSubmitButtonClicked }) {
+function EditButtonTemplate({ onSubmitButtonClicked, modalTitle }) {
 	const [isModalOpen, setIsModalOpen] = useState(false)
-	const modalTitle =
-		detailType === TypeOfEditButton.BIO ? "Edit Your Bio" : "Edit Your About"
 
 	const textBox = (
 		<ModalTextBox
@@ -75,26 +44,13 @@ function verifyUserOwnsProfile(id) {
 	return true
 }
 
-export function AboutEditButton() {
-	const { id } = useParams()
-	if (!verifyUserOwnsProfile(id)) return null
+export function EditProfileTextButton({ modalTitle, onSubmitButtonClicked, profileId }) {
+	if (!verifyUserOwnsProfile(profileId)) return null
 
 	return (
 		<EditButtonTemplate
-			detailType={TypeOfEditButton.ABOUT}
-			onSubmitButtonClicked={onAboutModalSubmitButtonClicked}
-		/>
-	)
-}
-
-export function BioEditButton() {
-	const { id } = useParams()
-	if (!verifyUserOwnsProfile(id)) return null
-
-	return (
-		<EditButtonTemplate
-			detailType={TypeOfEditButton.BIO}
-			onSubmitButtonClicked={onBioModalSubmitButtonClicked}
+			onSubmitButtonClicked={onSubmitButtonClicked}
+			modalTitle={modalTitle}
 		/>
 	)
 }

--- a/frontend/src/components/Profile/EditButtonUtils.jsx
+++ b/frontend/src/components/Profile/EditButtonUtils.jsx
@@ -1,5 +1,9 @@
 import { TOKEN_SESSION_KEY, BASEURL, AccountType } from "../../utils/globalUtils"
+import { useContext } from "react"
+import { UserProfileContext } from "../Profile/UserProfile"
+import { TeamProfileContext } from "../Profile/TeamProfile"
 import { LOGIN_FAILURE } from "../../api"
+import { TypeOfEditButton } from "./EditButton"
 
 export async function modalSubmitHelper(textValue, detailType, accountType, id) {
 	const token = sessionStorage.getItem(TOKEN_SESSION_KEY)
@@ -7,11 +11,10 @@ export async function modalSubmitHelper(textValue, detailType, accountType, id) 
 		return
 	}
 
-	const profileType = accountType === AccountType.PLAYER ? "profiles" : "teams"
 	detailType = detailType.toUpperCase()
 
 	try {
-		const response = await fetch(`${BASEURL}/api/${profileType}/edit`, {
+		const response = await fetch(`${BASEURL}/api/profiles/edit`, {
 			method: "PATCH",
 			headers: {
 				"Content-Type": "application/json",
@@ -21,6 +24,7 @@ export async function modalSubmitHelper(textValue, detailType, accountType, id) 
 				accountId: id,
 				editType: detailType,
 				value: textValue,
+				accountType: accountType,
 			}),
 		})
 
@@ -32,5 +36,53 @@ export async function modalSubmitHelper(textValue, detailType, accountType, id) 
 		}
 	} catch (error) {
 		console.error(`Error while attempting to update ${detailType}:`, error)
+	}
+}
+
+async function submitHelper(textValue, typeOfEditButton, accountType, id, setButtonText) {
+	const updatedAboutObject = await modalSubmitHelper(
+		textValue,
+		typeOfEditButton,
+		accountType,
+		id
+	)
+	if (updatedAboutObject.updatedValue != null)
+		setButtonText(updatedAboutObject.updatedValue)
+}
+
+export function onAboutModalSubmitButtonClicked(textValue) {
+	const { setAbout, id } = useContext(UserProfileContext)
+	return async function () {
+		submitHelper(textValue, TypeOfEditButton.ABOUT, AccountType.PLAYER, id, setAbout)
+	}
+}
+export function onBioModalSubmitButtonClicked(textValue) {
+	const { setBio, id } = useContext(UserProfileContext)
+	return async function () {
+		submitHelper(textValue, TypeOfEditButton.BIO, AccountType.PLAYER, id, setBio)
+	}
+}
+export function onDescriptionModalSubmitButtonClicked(textValue) {
+	const { setDescription, id } = useContext(TeamProfileContext)
+	return async function () {
+		submitHelper(
+			textValue,
+			TypeOfEditButton.DESCRIPTION,
+			AccountType.TEAM,
+			id,
+			setDescription
+		)
+	}
+}
+export function onOverviewModalSubmitButtonClicked(textValue) {
+	const { setOverview, id } = useContext(TeamProfileContext)
+	return async function () {
+		submitHelper(
+			textValue,
+			TypeOfEditButton.OVERVIEW,
+			AccountType.TEAM,
+			id,
+			setOverview
+		)
 	}
 }

--- a/frontend/src/components/Profile/EditButtonUtils.jsx
+++ b/frontend/src/components/Profile/EditButtonUtils.jsx
@@ -1,11 +1,7 @@
 import { TOKEN_SESSION_KEY, BASEURL, AccountType } from "../../utils/globalUtils"
-import { useContext } from "react"
-import { UserProfileContext } from "../Profile/UserProfile"
-import { TeamProfileContext } from "../Profile/TeamProfile"
 import { LOGIN_FAILURE } from "../../api"
-import { TypeOfEditButton } from "./EditButton"
 
-export async function modalSubmitHelper(textValue, detailType, accountType, id) {
+export async function modalSubmitHelper(textValue, detailType, accountType, id, setButtonText) {
 	const token = sessionStorage.getItem(TOKEN_SESSION_KEY)
 	if (token == null) {
 		return
@@ -29,60 +25,13 @@ export async function modalSubmitHelper(textValue, detailType, accountType, id) 
 		})
 
 		if (response.ok === true) {
-			const data = await response.json()
-			return data
+			const profileTextInformation = await response.json()
+			setButtonText(profileTextInformation.updatedValue)
+			return profileTextInformation
 		} else {
 			return LOGIN_FAILURE
 		}
 	} catch (error) {
 		console.error(`Error while attempting to update ${detailType}:`, error)
-	}
-}
-
-async function submitHelper(textValue, typeOfEditButton, accountType, id, setButtonText) {
-	const updatedAboutObject = await modalSubmitHelper(
-		textValue,
-		typeOfEditButton,
-		accountType,
-		id
-	)
-	if (updatedAboutObject.updatedValue != null)
-		setButtonText(updatedAboutObject.updatedValue)
-}
-
-export function onAboutModalSubmitButtonClicked(textValue) {
-	const { setAbout, id } = useContext(UserProfileContext)
-	return async function () {
-		submitHelper(textValue, TypeOfEditButton.ABOUT, AccountType.PLAYER, id, setAbout)
-	}
-}
-export function onBioModalSubmitButtonClicked(textValue) {
-	const { setBio, id } = useContext(UserProfileContext)
-	return async function () {
-		submitHelper(textValue, TypeOfEditButton.BIO, AccountType.PLAYER, id, setBio)
-	}
-}
-export function onDescriptionModalSubmitButtonClicked(textValue) {
-	const { setDescription, id } = useContext(TeamProfileContext)
-	return async function () {
-		submitHelper(
-			textValue,
-			TypeOfEditButton.DESCRIPTION,
-			AccountType.TEAM,
-			id,
-			setDescription
-		)
-	}
-}
-export function onOverviewModalSubmitButtonClicked(textValue) {
-	const { setOverview, id } = useContext(TeamProfileContext)
-	return async function () {
-		submitHelper(
-			textValue,
-			TypeOfEditButton.OVERVIEW,
-			AccountType.TEAM,
-			id,
-			setOverview
-		)
 	}
 }

--- a/frontend/src/components/Profile/TeamProfile.jsx
+++ b/frontend/src/components/Profile/TeamProfile.jsx
@@ -1,13 +1,12 @@
 import { EditProfileTextButton, TypeOfEditButton } from "./EditButton"
 import { modalSubmitHelper } from "./EditButtonUtils"
-import { createContext, useState } from "react"
+import { useState } from "react"
 import { useParams } from "react-router-dom"
 import { getAccountDataFromSessionStorage, AccountType } from "../../utils/globalUtils"
 import ApplyButton from "./ApplyButton"
 import "./ProfilePage.css"
 
 const defaultProfileInfo = ""
-export const TeamProfileContext = createContext()
 
 export default function TeamProfile({ isLoading, accountData, setIsLoading }) {
 	if (isLoading || accountData.playerId != null) {
@@ -23,75 +22,71 @@ export default function TeamProfile({ isLoading, accountData, setIsLoading }) {
 	const sessionStorageAccountData = getAccountDataFromSessionStorage()
 
 	return (
-		<TeamProfileContext.Provider value={{ setDescription, setOverview, id }}>
-			<div className="profile-page">
-				<div className="profile-banner">
-					<div className="profile-picture">
-						<div className="profile-picture-placeholder">
-							{accountData.name.charAt(0)}
-						</div>
+		<div className="profile-page">
+			<div className="profile-banner">
+				<div className="profile-picture">
+					<div className="profile-picture-placeholder">
+						{accountData.name.charAt(0)}
 					</div>
 				</div>
-				<div className="profile-header">
-					<div className="profile-info">
-						<h1 className="profile-name">{`${accountData.name}`}</h1>
-						<div className="profile-title">
-							<p className="profile-title-text">{`${
-								description || defaultProfileInfo
-							}`}</p>
-							<EditProfileTextButton
-								modalTitle={"Edit Description"}
-								onSubmitButtonClicked={(textValue) =>
-									modalSubmitHelper(
-										textValue,
-										TypeOfEditButton.DESCRIPTION,
-										AccountType.TEAM,
-										id,
-										setDescription
-									)
-								}
-								profileId={id}
-							/>
-						</div>
-						<p className="profile-location">📍 {accountData.location}</p>
-					</div>
-					<div>
-						<div>
-							<button>Home</button>
-							<button>Roster</button>
-							{sessionStorageAccountData &&
-								sessionStorageAccountData.accountType !=
-									AccountType.TEAM &&
-								sessionStorageAccountData.id !==
-									accountData.accountId && (
-									<ApplyButton
-										playerAccountId={sessionStorageAccountData.id}
-										teamAccountId={accountData.accountId}
-									/>
-								)}
-						</div>
-					</div>
-				</div>
-				<div className="profile-about">
-					<div className="profile-about-header">
-						<h3>Overview</h3>
+			</div>
+			<div className="profile-header">
+				<div className="profile-info">
+					<h1 className="profile-name">{`${accountData.name}`}</h1>
+					<div className="profile-title">
+						<p className="profile-title-text">{`${
+							description || defaultProfileInfo
+						}`}</p>
 						<EditProfileTextButton
-							modalTitle={"Edit Overview"}
+							modalTitle={"Edit Description"}
 							onSubmitButtonClicked={(textValue) =>
 								modalSubmitHelper(
-										textValue,
-										TypeOfEditButton.OVERVIEW,
-										AccountType.TEAM,
-										id,
-										setOverview
-									)
+									textValue,
+									TypeOfEditButton.DESCRIPTION,
+									AccountType.TEAM,
+									id,
+									setDescription
+								)
 							}
 							profileId={id}
 						/>
 					</div>
-					<p className="profile-about-text">{`${overview}`}</p>
+					<p className="profile-location">📍 {accountData.location}</p>
+				</div>
+				<div>
+					<div>
+						<button>Home</button>
+						<button>Roster</button>
+						{sessionStorageAccountData &&
+							sessionStorageAccountData.accountType != AccountType.TEAM &&
+							sessionStorageAccountData.id !== accountData.accountId && (
+								<ApplyButton
+									playerAccountId={sessionStorageAccountData.id}
+									teamAccountId={accountData.accountId}
+								/>
+							)}
+					</div>
 				</div>
 			</div>
-		</TeamProfileContext.Provider>
+			<div className="profile-about">
+				<div className="profile-about-header">
+					<h3>Overview</h3>
+					<EditProfileTextButton
+						modalTitle={"Edit Overview"}
+						onSubmitButtonClicked={(textValue) =>
+							modalSubmitHelper(
+								textValue,
+								TypeOfEditButton.OVERVIEW,
+								AccountType.TEAM,
+								id,
+								setOverview
+							)
+						}
+						profileId={id}
+					/>
+				</div>
+				<p className="profile-about-text">{`${overview}`}</p>
+			</div>
+		</div>
 	)
 }

--- a/frontend/src/components/Profile/TeamProfile.jsx
+++ b/frontend/src/components/Profile/TeamProfile.jsx
@@ -1,4 +1,10 @@
+import { EditProfileTextButton } from "./EditButton"
+import {
+	onDescriptionModalSubmitButtonClicked,
+	onOverviewModalSubmitButtonClicked,
+} from "./EditButtonUtils"
 import { createContext, useState } from "react"
+import { useParams } from "react-router-dom"
 import { getAccountDataFromSessionStorage, AccountType } from "../../utils/globalUtils"
 import ApplyButton from "./ApplyButton"
 import "./ProfilePage.css"
@@ -11,6 +17,7 @@ export default function TeamProfile({ isLoading, accountData }) {
 		return <h1>Loading...</h1>
 	}
 
+	const { id } = useParams()
 	const [description, setDescription] = useState(
 		accountData.description || defaultProfileInfo
 	)
@@ -18,7 +25,7 @@ export default function TeamProfile({ isLoading, accountData }) {
 	const sessionStorageAccountData = getAccountDataFromSessionStorage()
 
 	return (
-		<TeamProfileContext.Provider value={{ setDescription, setOverview }}>
+		<TeamProfileContext.Provider value={{ setDescription, setOverview, id }}>
 			<div className="profile-page">
 				<div className="profile-banner">
 					<div className="profile-picture">
@@ -34,6 +41,13 @@ export default function TeamProfile({ isLoading, accountData }) {
 							<p className="profile-title-text">{`${
 								description || defaultProfileInfo
 							}`}</p>
+							<EditProfileTextButton
+								modalTitle={"Edit Description"}
+								onSubmitButtonClicked={
+									onDescriptionModalSubmitButtonClicked
+								}
+								profileId={id}
+							/>
 						</div>
 						<p className="profile-location">📍 {accountData.location}</p>
 					</div>
@@ -57,6 +71,11 @@ export default function TeamProfile({ isLoading, accountData }) {
 				<div className="profile-about">
 					<div className="profile-about-header">
 						<h3>Overview</h3>
+						<EditProfileTextButton
+							modalTitle={"Edit Overview"}
+							onSubmitButtonClicked={onOverviewModalSubmitButtonClicked}
+							profileId={id}
+						/>
 					</div>
 					<p className="profile-about-text">{`${overview}`}</p>
 				</div>

--- a/frontend/src/components/Profile/TeamProfile.jsx
+++ b/frontend/src/components/Profile/TeamProfile.jsx
@@ -1,8 +1,5 @@
-import { EditProfileTextButton } from "./EditButton"
-import {
-	onDescriptionModalSubmitButtonClicked,
-	onOverviewModalSubmitButtonClicked,
-} from "./EditButtonUtils"
+import { EditProfileTextButton, TypeOfEditButton } from "./EditButton"
+import { modalSubmitHelper } from "./EditButtonUtils"
 import { createContext, useState } from "react"
 import { useParams } from "react-router-dom"
 import { getAccountDataFromSessionStorage, AccountType } from "../../utils/globalUtils"
@@ -43,8 +40,14 @@ export default function TeamProfile({ isLoading, accountData }) {
 							}`}</p>
 							<EditProfileTextButton
 								modalTitle={"Edit Description"}
-								onSubmitButtonClicked={
-									onDescriptionModalSubmitButtonClicked
+								onSubmitButtonClicked={(textValue) =>
+									modalSubmitHelper(
+										textValue,
+										TypeOfEditButton.DESCRIPTION,
+										AccountType.TEAM,
+										id,
+										setDescription
+									)
 								}
 								profileId={id}
 							/>
@@ -73,7 +76,15 @@ export default function TeamProfile({ isLoading, accountData }) {
 						<h3>Overview</h3>
 						<EditProfileTextButton
 							modalTitle={"Edit Overview"}
-							onSubmitButtonClicked={onOverviewModalSubmitButtonClicked}
+							onSubmitButtonClicked={(textValue) =>
+								modalSubmitHelper(
+										textValue,
+										TypeOfEditButton.OVERVIEW,
+										AccountType.TEAM,
+										id,
+										setOverview
+									)
+							}
 							profileId={id}
 						/>
 					</div>

--- a/frontend/src/components/Profile/UserProfile.jsx
+++ b/frontend/src/components/Profile/UserProfile.jsx
@@ -1,8 +1,6 @@
-import { EditProfileTextButton } from "./EditButton"
-import {
-	onBioModalSubmitButtonClicked,
-	onAboutModalSubmitButtonClicked,
-} from "./EditButtonUtils"
+import { EditProfileTextButton, TypeOfEditButton } from "./EditButton"
+import { AccountType } from "../../utils/globalUtils"
+import { modalSubmitHelper } from "./EditButtonUtils"
 import { useParams } from "react-router-dom"
 import { createContext, useState } from "react"
 import "./ProfilePage.css"
@@ -36,7 +34,15 @@ export default function UserProfile({ isLoading, accountData }) {
 							<p className="profile-title-text">{`${bio}`}</p>
 							<EditProfileTextButton
 								modalTitle={"Edit Bio"}
-								onSubmitButtonClicked={onBioModalSubmitButtonClicked}
+								onSubmitButtonClicked={(textValue) =>
+									modalSubmitHelper(
+										textValue,
+										TypeOfEditButton.BIO,
+										AccountType.PLAYER,
+										id,
+										setBio
+									)
+								}
 								profileId={id}
 							/>
 						</div>
@@ -48,7 +54,15 @@ export default function UserProfile({ isLoading, accountData }) {
 						<h3>About</h3>
 						<EditProfileTextButton
 							modalTitle={"Edit About"}
-							onSubmitButtonClicked={onAboutModalSubmitButtonClicked}
+							onSubmitButtonClicked={(textValue) =>
+								modalSubmitHelper(
+									textValue,
+									TypeOfEditButton.ABOUT,
+									AccountType.PLAYER,
+									id,
+									setAbout
+								)
+							}
 							profileId={id}
 						/>
 					</div>

--- a/frontend/src/components/Profile/UserProfile.jsx
+++ b/frontend/src/components/Profile/UserProfile.jsx
@@ -2,11 +2,9 @@ import { EditProfileTextButton, TypeOfEditButton } from "./EditButton"
 import { AccountType } from "../../utils/globalUtils"
 import { modalSubmitHelper } from "./EditButtonUtils"
 import { useParams } from "react-router-dom"
-import { createContext, useState } from "react"
+import { useState } from "react"
 import "./ProfilePage.css"
 const defaultProfileInfo = ""
-
-export const UserProfileContext = createContext()
 
 export default function UserProfile({ isLoading, accountData, setIsLoading }) {
 	if (isLoading || accountData.teamId != null) {
@@ -14,73 +12,60 @@ export default function UserProfile({ isLoading, accountData, setIsLoading }) {
 		return <h1>Loading...</h1>
 	}
 
-	useEffect(() => {
-		setLoggedInAccountData(getAccountDataFromSessionStorage())
-	}, [])
-
-	useEffect(() => {
-		setLoggedInAccountData(getAccountDataFromSessionStorage())
-	}, [])
-
 	const [bio, setBio] = useState(accountData.bio || defaultProfileInfo)
 	const [about, setAbout] = useState(accountData.about || defaultProfileInfo)
-	const [loggedInAccountData, setLoggedInAccountData] = useState(null)
 	const { id } = useParams()
 
 	return (
-		<UserProfileContext.Provider
-			value={{ setAbout, setBio, loggedInAccountData, id }}
-		>
-			<div className="profile-page">
-				<div className="profile-banner">
-					<div className="profile-picture">
-						<div className="profile-picture-placeholder">
-							{accountData.firstName.charAt(0)}
-						</div>
+		<div className="profile-page">
+			<div className="profile-banner">
+				<div className="profile-picture">
+					<div className="profile-picture-placeholder">
+						{accountData.firstName.charAt(0)}
 					</div>
 				</div>
-				<div className="profile-header">
-					<div className="profile-info">
-						<h1 className="profile-name">{`${accountData.firstName} ${accountData.lastName}`}</h1>
-						<div className="profile-title">
-							<p className="profile-title-text">{`${bio}`}</p>
-							<EditProfileTextButton
-								modalTitle={"Edit Bio"}
-								onSubmitButtonClicked={(textValue) =>
-									modalSubmitHelper(
-										textValue,
-										TypeOfEditButton.BIO,
-										AccountType.PLAYER,
-										id,
-										setBio
-									)
-								}
-								profileId={id}
-							/>
-						</div>
-						<p className="profile-location">📍 {accountData.location}</p>
-					</div>
-				</div>
-				<div className="profile-about">
-					<div className="profile-about-header">
-						<h3>About</h3>
+			</div>
+			<div className="profile-header">
+				<div className="profile-info">
+					<h1 className="profile-name">{`${accountData.firstName} ${accountData.lastName}`}</h1>
+					<div className="profile-title">
+						<p className="profile-title-text">{`${bio}`}</p>
 						<EditProfileTextButton
-							modalTitle={"Edit About"}
+							modalTitle={"Edit Bio"}
 							onSubmitButtonClicked={(textValue) =>
 								modalSubmitHelper(
 									textValue,
-									TypeOfEditButton.ABOUT,
+									TypeOfEditButton.BIO,
 									AccountType.PLAYER,
 									id,
-									setAbout
+									setBio
 								)
 							}
 							profileId={id}
 						/>
 					</div>
-					<p className="profile-about-text">{`${about}`}</p>
+					<p className="profile-location">📍 {accountData.location}</p>
 				</div>
 			</div>
-		</UserProfileContext.Provider>
+			<div className="profile-about">
+				<div className="profile-about-header">
+					<h3>About</h3>
+					<EditProfileTextButton
+						modalTitle={"Edit About"}
+						onSubmitButtonClicked={(textValue) =>
+							modalSubmitHelper(
+								textValue,
+								TypeOfEditButton.ABOUT,
+								AccountType.PLAYER,
+								id,
+								setAbout
+							)
+						}
+						profileId={id}
+					/>
+				</div>
+				<p className="profile-about-text">{`${about}`}</p>
+			</div>
+		</div>
 	)
 }

--- a/frontend/src/components/Profile/UserProfile.jsx
+++ b/frontend/src/components/Profile/UserProfile.jsx
@@ -1,4 +1,9 @@
-import { AboutEditButton, BioEditButton } from "./EditButton"
+import { EditProfileTextButton } from "./EditButton"
+import {
+	onBioModalSubmitButtonClicked,
+	onAboutModalSubmitButtonClicked,
+} from "./EditButtonUtils"
+import { useParams } from "react-router-dom"
 import { createContext, useState } from "react"
 import "./ProfilePage.css"
 const defaultProfileInfo = ""
@@ -10,11 +15,12 @@ export default function UserProfile({ isLoading, accountData }) {
 		return <h1>Loading...</h1>
 	}
 
+	const { id } = useParams()
 	const [bio, setBio] = useState(accountData.bio || defaultProfileInfo)
 	const [about, setAbout] = useState(accountData.about || defaultProfileInfo)
 
 	return (
-		<UserProfileContext.Provider value={{ setAbout, setBio }}>
+		<UserProfileContext.Provider value={{ setAbout, setBio, id, bio, about }}>
 			<div className="profile-page">
 				<div className="profile-banner">
 					<div className="profile-picture">
@@ -28,7 +34,11 @@ export default function UserProfile({ isLoading, accountData }) {
 						<h1 className="profile-name">{`${accountData.firstName} ${accountData.lastName}`}</h1>
 						<div className="profile-title">
 							<p className="profile-title-text">{`${bio}`}</p>
-							<BioEditButton />
+							<EditProfileTextButton
+								modalTitle={"Edit Bio"}
+								onSubmitButtonClicked={onBioModalSubmitButtonClicked}
+								profileId={id}
+							/>
 						</div>
 						<p className="profile-location">📍 {accountData.location}</p>
 					</div>
@@ -36,7 +46,11 @@ export default function UserProfile({ isLoading, accountData }) {
 				<div className="profile-about">
 					<div className="profile-about-header">
 						<h3>About</h3>
-						<AboutEditButton />
+						<EditProfileTextButton
+							modalTitle={"Edit About"}
+							onSubmitButtonClicked={onAboutModalSubmitButtonClicked}
+							profileId={id}
+						/>
 					</div>
 					<p className="profile-about-text">{`${about}`}</p>
 				</div>


### PR DESCRIPTION
## Description
This PR allows team accounts to edit their profile description. Previously, this feature was exclusive to player accounts. Future PRs will improve the user experience through features such as automatic modal closing and text auto-filling.

## Screenshots
_Edit profile modals_
<img width="1003" height="748" alt="Screenshot 2025-07-11 at 1 31 34 PM" src="https://github.com/user-attachments/assets/7ac2bdd4-b5be-48f7-aa06-3d77dd14c14a" />
<img width="1003" height="748" alt="Screenshot 2025-07-11 at 1 31 47 PM" src="https://github.com/user-attachments/assets/1a98d01e-7e6c-473d-a002-ccc14cded3b5" />
_Team profiles_
<img width="1003" height="611" alt="Screenshot 2025-07-11 at 1 32 24 PM" src="https://github.com/user-attachments/assets/d0362219-37f8-4fae-a7cc-66bf1d5a0749" />

## Video preview
https://github.com/user-attachments/assets/9acc19bd-f5c7-4ca4-a6e2-cb230cd7af98

