### PR TITLE
feature: Add active tournaments page

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -66,3 +66,11 @@ export async function createTeamApplication(playerAccountId, teamAccountId) {
 		console.error("Error creating application:", error)
 	}
 }
+
+export async function createNewTournament(accountId) {
+	//TODO: Get newly created tournament from backend endpoint
+}
+
+export async function getAllTournaments(accountId) {
+	//TODO: Get all tournaments from backend endpoint
+}

--- a/frontend/src/components/Tournaments/CreateTournamentButton.jsx
+++ b/frontend/src/components/Tournaments/CreateTournamentButton.jsx
@@ -1,0 +1,21 @@
+import { useContext } from "react"
+import { createNewTournament } from "../../api"
+import { TournamentContext } from "../../pages/TournamentsPage"
+
+export function CreateTournamentButton({ teamAccountId, email }) {
+	const { setTournaments, tournaments } = useContext(TournamentContext)
+
+	return (
+		<div className="button-holder">
+			<button
+				className="create-tournament-btn"
+				onClick={async () => {
+					const data = await createNewTournament(teamAccountId, email)
+					setTournaments([...tournaments, data])
+				}}
+			>
+				Create Tournament
+			</button>
+		</div>
+	)
+}

--- a/frontend/src/components/Tournaments/TournamentTile.jsx
+++ b/frontend/src/components/Tournaments/TournamentTile.jsx
@@ -1,0 +1,14 @@
+import { useNavigate } from "react-router-dom"
+export function TournamentTile({ tournamentInformation }) {
+	const navigate = useNavigate()
+
+	const tournamentCreatorAccountId = tournamentInformation.creatorAccountId
+	const tournamentCreaterInformation = tournamentInformation.allParticipants[tournamentCreatorAccountId]
+
+	return (
+		<div className="tournament-tile pointer" onClick={() => navigate(`/tournaments/${tournamentInformation.tournamentId}`)}>
+			<h2>{tournamentInformation.name}</h2>
+			{tournamentCreaterInformation && <p>Created by: {tournamentCreaterInformation.name}</p>}
+		</div>
+	)
+}

--- a/frontend/src/components/Tournaments/TournamentTile.jsx
+++ b/frontend/src/components/Tournaments/TournamentTile.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom"
+
 export function TournamentTile({ tournamentInformation }) {
 	const navigate = useNavigate()
 

--- a/frontend/src/components/Tournaments/TournamentsPage.css
+++ b/frontend/src/components/Tournaments/TournamentsPage.css
@@ -1,0 +1,82 @@
+.tournaments-container {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+	margin: 0 auto;
+	margin-top: 15px;
+	width: 70%;
+}
+
+.tournament-tile {
+	background-color: #ffffff;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+	padding: 15px 15px 15px 15px;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+	transition: box-shadow 0.2s ease;
+	display: flex;
+	flex-direction: column;
+	gap: 0px;
+}
+
+.tournament-tile p {
+	margin: 0px;
+	margin-bottom: 10px;
+}
+
+.tournament-tile h2 {
+margin-top: 10px;
+	margin-bottom: 5px;
+}
+.tournament-tile.pointer {
+	cursor: pointer;
+}
+
+.tournament-tile.centered {
+	margin: 0 auto;
+	margin-top: 10px;
+	width: 80%;
+}
+
+.tournament-tile.centered h2 {
+	margin: auto;
+}
+
+.create-tournament-btn {
+	width: 35%;
+	margin: 0 auto;
+  margin-top: 10px;
+	padding: 12px 24px;
+	border-radius: 24px;
+	font-size: 14px;
+	font-weight: 600;
+	cursor: pointer;
+	transition: all 0.2s ease;
+	border: none;
+	background: #0077b5;
+	color: white;
+}
+
+.button-holder {
+  display: flex;
+}
+
+.create-tournament-btn:hover {
+	background: #005885;
+}
+
+.tournament-btn {
+	padding: 8px 160px;
+	border: 1px solid #0073b1;
+	border-radius: 24px;
+	background-color: transparent;
+	color: #0073b1;
+	font-weight: 600;
+	font-size: 14px;
+	cursor: pointer;
+	transition: all 0.2s ease;
+}
+
+.tournament-btn:hover {
+	box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.08);
+}

--- a/frontend/src/components/TournamentsBracket/IntermissionDisplay.jsx
+++ b/frontend/src/components/TournamentsBracket/IntermissionDisplay.jsx
@@ -1,0 +1,81 @@
+import { useContext } from "react"
+import { useNavigate } from "react-router-dom"
+import { BASEURL } from "../../utils/globalUtils"
+import { TournamentContext } from "../../pages/BracketPage"
+import Navbar from "../Navbar/Navbar"
+
+export const TournamentStateOptions = {
+	INTERMISSION: "intermission",
+	ACTIVE: "active",
+}
+
+async function startTournament(tournamentInformation, setIsLoading) {
+	try {
+		setIsLoading(true)
+		const response = await fetch(
+			`${BASEURL}/tournaments/start/${tournamentInformation.tournamentId}`
+		)
+		await response.json()
+		setIsLoading(false)
+	} catch (error) {
+		console.error("Error retrieving profile data:", error)
+	}
+}
+
+export default function IntermissionDisplay({ tournamentInformation }) {
+	if (tournamentInformation == null) return
+	const navigate = useNavigate()
+	const { setIsLoading, isLoading } = useContext(TournamentContext)
+
+	const allParticipants = tournamentInformation.allParticipants
+	const minimumParticipants = tournamentInformation.minimumParticipants
+	const numberOfParticipants = Object.keys(allParticipants).length
+	const canStartTournament = numberOfParticipants >= minimumParticipants
+
+    console.log(tournamentInformation)
+
+	return (
+		<>
+			<Navbar />
+			<div className="tournament-intermission">
+				<div className="tournament-intermission-information">
+					<h1>{`${numberOfParticipants}/${minimumParticipants} Participants`}</h1>
+					{canStartTournament && (
+						<button
+							className="tournament-start-btn"
+							onClick={() =>
+								startTournament(
+									tournamentInformation,
+									setIsLoading
+								)
+							}
+						>
+							Start Tournament
+						</button>
+					)}
+				</div>
+
+				<div className="tournament-intermission-teams">
+					{Object.values(allParticipants).map((teamInformation) => {
+						return (
+							<div
+								className="post"
+								onClick={() =>
+									navigate(`/teams/${teamInformation.accountId}`)
+								}
+							>
+								<div className="apply-profile-picture"></div>
+								<div className="apply-details">
+									<h2>{teamInformation.name}</h2>
+									<div className="post-information">
+										<h3>{teamInformation.description}</h3>
+									</div>
+								</div>
+							</div>
+						)
+					})}
+				</div>
+			</div>
+		</>
+	)
+}

--- a/frontend/src/components/TournamentsBracket/IntermissionDisplay.jsx
+++ b/frontend/src/components/TournamentsBracket/IntermissionDisplay.jsx
@@ -1,7 +1,10 @@
-import { useContext } from "react"
+import { useEffect } from "react"
 import { useNavigate } from "react-router-dom"
-import { BASEURL } from "../../utils/globalUtils"
-import { TournamentContext } from "../../pages/BracketPage"
+import {
+	BASEURL,
+	getAccountDataFromSessionStorage,
+	AccountType,
+} from "../../utils/globalUtils"
 import Navbar from "../Navbar/Navbar"
 
 export const TournamentStateOptions = {
@@ -15,6 +18,7 @@ async function startTournament(tournamentInformation, setIsLoading) {
 		const response = await fetch(
 			`${BASEURL}/tournaments/start/${tournamentInformation.tournamentId}`
 		)
+
 		await response.json()
 		setIsLoading(false)
 	} catch (error) {
@@ -22,17 +26,46 @@ async function startTournament(tournamentInformation, setIsLoading) {
 	}
 }
 
-export default function IntermissionDisplay({ tournamentInformation }) {
-	if (tournamentInformation == null) return
-	const navigate = useNavigate()
-	const { setIsLoading, isLoading } = useContext(TournamentContext)
+async function joinTournament(tournamentInformation) {
+	try {
+		const response = await fetch(`${BASEURL}/tournaments/join/`, {
+			method: "PATCH",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				teamAccountId: teamAccountId,
+				tournamentId: tournamentInformation.tournamentId,
+			}),
+		})
+		await response.json()
+	} catch (error) {
+		console.error("Error retrieving profile data:", error)
+	}
+}
 
+function verifyUserIsLoggedIn(navigate, loggedInAccount) {
+	if (!loggedInAccount || !loggedInAccount.id || !loggedInAccount.accountType) {
+		navigate("/")
+	}
+}
+
+export default function IntermissionDisplay({ tournamentInformation, setIsLoading }) {
+	if (tournamentInformation == null) return
+
+	const navigate = useNavigate()
 	const allParticipants = tournamentInformation.allParticipants
 	const minimumParticipants = tournamentInformation.minimumParticipants
 	const numberOfParticipants = Object.keys(allParticipants).length
-	const canStartTournament = numberOfParticipants >= minimumParticipants
+	const loggedInAccount = getAccountDataFromSessionStorage()
 
-    console.log(tournamentInformation)
+	useEffect(() => {
+		verifyUserIsLoggedIn(navigate, loggedInAccount)
+	}, [])
+
+	const canStartTournament = numberOfParticipants >= minimumParticipants
+	const isTournamentCreator =true
+		//tournamentInformation.creatorAccountId === loggedInAccount.accountId
 
 	return (
 		<>
@@ -40,19 +73,26 @@ export default function IntermissionDisplay({ tournamentInformation }) {
 			<div className="tournament-intermission">
 				<div className="tournament-intermission-information">
 					<h1>{`${numberOfParticipants}/${minimumParticipants} Participants`}</h1>
-					{canStartTournament && (
+					{canStartTournament && isTournamentCreator && (
 						<button
 							className="tournament-start-btn"
 							onClick={() =>
-								startTournament(
-									tournamentInformation,
-									setIsLoading
-								)
+								startTournament(tournamentInformation, setIsLoading)
 							}
 						>
 							Start Tournament
 						</button>
 					)}
+					{!canStartTournament &&
+						!isTournamentCreator &&
+						loggedInAccount.accountType == AccountType.TEAM && (
+							<button
+								className="tournament-start-btn"
+								onClick={() => joinTournament(tournamentInformation)}
+							>
+								Join Tournament
+							</button>
+						)}
 				</div>
 
 				<div className="tournament-intermission-teams">

--- a/frontend/src/components/TournamentsBracket/IntermissionDisplay.jsx
+++ b/frontend/src/components/TournamentsBracket/IntermissionDisplay.jsx
@@ -64,8 +64,7 @@ export default function IntermissionDisplay({ tournamentInformation, setIsLoadin
 	}, [])
 
 	const canStartTournament = numberOfParticipants >= minimumParticipants
-	const isTournamentCreator =true
-		//tournamentInformation.creatorAccountId === loggedInAccount.accountId
+	const isTournamentCreator = tournamentInformation.creatorAccountId === loggedInAccount.accountId
 
 	return (
 		<>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,6 +8,7 @@ import ProfilePage from "./pages/ProfilePage.jsx"
 import PrivateRoute from "./utils/PrivateRoute.jsx"
 import ConnectPage from "./pages/ConnectPage.jsx"
 import ApplyPage from "./pages/ApplyPage.jsx"
+import TournamentsPage from  "./pages/TournamentsPage.jsx"
 
 const CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID
 

--- a/frontend/src/pages/TournamentsPage.jsx
+++ b/frontend/src/pages/TournamentsPage.jsx
@@ -1,0 +1,79 @@
+import { createContext, useState, useEffect } from "react"
+import { useNavigate } from "react-router-dom"
+import { getAllTournaments } from "../api"
+import { CreateTournamentButton } from "../components/Tournaments/CreateTournamentButton"
+import { TournamentTile } from "../components/Tournaments/TournamentTile"
+import {
+	AccountType,
+	getAccountDataFromSessionStorage,
+	GOOGLE_EMAIL_KEY,
+} from "../utils/globalUtils"
+import Navbar from "../components/Navbar/Navbar"
+import "../components/Tournaments/TournamentsPage.css"
+
+export const TournamentContext = createContext()
+
+async function getTournaments(setTournaments) {
+	const tournamentData = await getAllTournaments()
+	setTournaments(tournamentData)
+}
+
+export default function TournamentsPage() {
+	const navigate = useNavigate()
+	const [tournaments, setTournaments] = useState([])
+
+	const sessionStorageAccountData = getAccountDataFromSessionStorage()
+	if (!sessionStorageAccountData) {
+		navigate("/")
+	}
+
+	const accountType = sessionStorageAccountData.accountType
+	const accountId = sessionStorageAccountData.id
+	const email = sessionStorage.getItem(GOOGLE_EMAIL_KEY)
+
+	if (!accountId || !accountType || !email) {
+		navigate("/")
+	}
+
+	useEffect(() => {
+		getTournaments(setTournaments)
+	}, [])
+
+	if (tournaments.length === 0) {
+		return (
+			<TournamentContext.Provider value={{ tournaments, setTournaments }}>
+				<Navbar />
+				<div className="tournament-tile centered">
+					<h2>No Active Tournaments At This Time</h2>
+				</div>
+				{accountType == AccountType.TEAM && (
+					<CreateTournamentButton teamAccountId={accountId} email={email} />
+				)}
+			</TournamentContext.Provider>
+		)
+	}
+
+	const tournamentTiles = tournaments.map((tournament) => {
+		return <TournamentTile key={tournament.id} tournamentInformation={tournament} />
+	})
+
+	tournamentTiles.sort((a, b) => {
+		const aDate = new Date(a.props.tournamentInformation.createdAt)
+		const bDate = new Date(b.props.tournamentInformation.createdAt)
+		return bDate - aDate
+	})
+
+	return (
+		<TournamentContext.Provider value={{ tournaments, setTournaments }}>
+			<Navbar />
+			<div className="tournaments-page">
+				<div className="tournaments-container">
+					{tournamentTiles}
+					{accountType == AccountType.TEAM && (
+						<CreateTournamentButton teamAccountId={accountId} email={email} />
+					)}
+				</div>
+			</div>
+		</TournamentContext.Provider>
+	)
+}


### PR DESCRIPTION
## Description
This PR adds the [TournamentsPage](https://github.com/XiWorl/PlayerLink/blob/f4e8b6cc06e5fb86b22ccb5303d48c24de639a1f/frontend/src/pages/TournamentsPage.jsx) frontend component, which is used to display all active tournaments to the user. A future PR will be creating the bracket visual components for the tournament scheduling, which will display all the matchups between teams.

## Video Preview
[A preview of the finished tournament page can be viewed here](https://pxl.cl/7MpFd)