### PR TITLE
feature: Add frontend for recommendations 

### DIFF
--- a/frontend/src/components/TeamApplications/Applications.jsx
+++ b/frontend/src/components/TeamApplications/Applications.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react"
 import { getApplicationsFromAccountId } from "../../api"
-import { createApplicationTile } from "./Utils"
+import { createApplicationTile, SidebarTabs, Sidebar } from "./Utils"
+import { AccountType } from "../../utils/globalUtils"
+import { Recommendations } from "./Recommendations"
 import "./ApplyPage.css"
 
 function EmptyApplicationsDisplay() {
@@ -8,23 +10,26 @@ function EmptyApplicationsDisplay() {
 		<div className="empty-applications">
 			<h2>No applications found</h2>
 		</div>
-    )
+	)
 }
 
 async function loadApplications(accountId, setApplicationsDisplay) {
 	const applications = await getApplicationsFromAccountId(accountId)
 
-    if (applications.length === 0) {
-        setApplicationsDisplay(<EmptyApplicationsDisplay />)
-        return
-    }
+	if (applications.length === 0) {
+		setApplicationsDisplay(<EmptyApplicationsDisplay />)
+		return
+	}
 
-	const newApplicationsDisplay = applications.map((applicationData) => createApplicationTile(applicationData))
-    setApplicationsDisplay(newApplicationsDisplay)
+	const newApplicationsDisplay = applications.map((applicationData) =>
+		createApplicationTile(applicationData)
+	)
+	setApplicationsDisplay(newApplicationsDisplay)
 }
 
 export function Applications({ accountData, accountId }) {
 	const [applicationsDisplay, setApplicationsDisplay] = useState([])
+	const [currentTab, setCurrentTab] = useState(SidebarTabs.APPLICATIONS)
 
 	useEffect(() => {
 		loadApplications(accountId, setApplicationsDisplay)
@@ -32,9 +37,26 @@ export function Applications({ accountData, accountId }) {
 
 	return (
 		<div className="apply-page">
-			<div className="page-content">
-				<div className="postings">{applicationsDisplay}</div>
-			</div>
+			{currentTab === SidebarTabs.APPLICATIONS && (
+				<div className="page-content">
+					<Sidebar
+						accountType={accountData.accountType}
+						setCurrentTab={setCurrentTab}
+					/>
+					<div className="postings">{applicationsDisplay}</div>
+				</div>
+			)}
+			{currentTab === SidebarTabs.RECOMMENDATIONS &&
+				accountData != null &&
+				accountData.accountType == AccountType.PLAYER && (
+					<div className="page-content">
+						<Sidebar
+							accountType={accountData.accountType}
+							setCurrentTab={setCurrentTab}
+						/>
+						<Recommendations accountId={accountId} />
+					</div>
+				)}
 		</div>
 	)
 }

--- a/frontend/src/components/TeamApplications/Recommendations.jsx
+++ b/frontend/src/components/TeamApplications/Recommendations.jsx
@@ -1,0 +1,93 @@
+import { useState, useEffect } from "react"
+import { useNavigate } from "react-router-dom"
+import { getRecommendations, updateRecommendationStatus } from "../../api"
+
+const RecommendationStatus = {
+	INTERESTED: "Interested",
+	NOT_INTERESTED: "Not Interested",
+}
+
+async function onRecommendationClick(status, playerAccountId, teamAccountId, navigate, setRecommendations) {
+    const updateRecommendations = await updateRecommendationStatus(playerAccountId, teamAccountId, status)
+
+	if (status === RecommendationStatus.INTERESTED) {
+		navigate(`/teams/${teamAccountId}`)
+	} else if (status === RecommendationStatus.NOT_INTERESTED) {
+        setRecommendations(updateRecommendations)
+	}
+}
+function RecommendationTile({ teamData, playerAccountId, setRecommendations }) {
+	const navigate = useNavigate()
+
+	return (
+		<div className="recommendation">
+			<h2
+				className="recommendation-h2"
+				onClick={() => {
+					navigate(`/teams/${teamData.team.accountId}`)
+				}}
+			>
+				{teamData.team.name}
+			</h2>
+			<div className="recommendation-buttons">
+				<button
+					className="recommendation-btn"
+					onClick={() =>
+						onRecommendationClick(
+							RecommendationStatus.NOT_INTERESTED,
+							playerAccountId,
+							teamData.team.accountId,
+							navigate, setRecommendations
+						)
+					}
+				>
+					Not Interested
+				</button>
+				<button
+					className="recommendation-btn accept"
+					onClick={() =>
+						onRecommendationClick(
+							RecommendationStatus.INTERESTED,
+							playerAccountId,
+							teamData.team.accountId,
+							navigate, setRecommendations
+						)
+					}
+				>
+					Interested
+				</button>
+			</div>
+		</div>
+	)
+}
+
+async function loadRecommendations(setRecommendations, accountId) {
+	const recommendations = await getRecommendations(accountId)
+	setRecommendations(recommendations)
+}
+
+export function Recommendations({ accountId }) {
+	const [recommendations, setRecommendations] = useState([])
+
+	useEffect(() => {
+		loadRecommendations(setRecommendations, accountId)
+	}, [])
+
+	recommendations.sort((a, b) => {
+		return b.score - a.score
+	})
+	return (
+		<div className="postings">
+			{recommendations.map((recommendation, index) => {
+				return (
+					<RecommendationTile
+						key={index}
+						teamData={recommendation}
+						playerAccountId={accountId}
+                        setRecommendations={setRecommendations}
+					/>
+				)
+			})}
+		</div>
+	)
+}

--- a/frontend/src/components/TeamApplications/Utils.jsx
+++ b/frontend/src/components/TeamApplications/Utils.jsx
@@ -1,6 +1,37 @@
 import { getProfileData } from "../../api"
 import { AccountType } from "../../utils/globalUtils"
 
+export const SidebarTabs = {
+	APPLICATIONS: "Applications",
+	RECOMMENDATIONS: "Recommendations",
+}
+
+export function Sidebar({ accountType, setCurrentTab }) {
+	const viewApplicationsButtonText =
+		accountType === AccountType.PLAYER ? "My Applications" : "View Applications"
+
+	return (
+		<div className="sidebar">
+			<div className="sidebar-options">
+				<button
+					className="sidebar-options-btn"
+					onClick={() => setCurrentTab(SidebarTabs.APPLICATIONS)}
+				>
+					{viewApplicationsButtonText}
+				</button>
+				{accountType === AccountType.PLAYER && (
+					<button
+						className="sidebar-options-btn"
+						onClick={() => setCurrentTab(SidebarTabs.RECOMMENDATIONS)}
+					>
+						Suggested For You
+					</button>
+				)}
+			</div>
+		</div>
+	)
+}
+
 export async function createApplicationTile(applicationData) {
 	const profileInformation = await getProfileData(AccountType.TEAM, applicationData.teamAccountId)
 


### PR DESCRIPTION
## Description
This PR adds the backend endpoints associated with the recommendation algorithm along with the client api fetch requests. This PR also updates the ApplyPage css styling. Lastly, this PR updates the player's profile visit count associated with that team every time they visit a team's profile.

## Video Preview
[Viewing recommendations](https://pxl.cl/7Mx0V)