### PR TITLE
feature: Add team filtering and account interactions updates

### DIFF
--- a/backend/prisma/migrations/20250725212721_db_initilize1/migration.sql
+++ b/backend/prisma/migrations/20250725212721_db_initilize1/migration.sql
@@ -22,9 +22,15 @@ CREATE TABLE "Player" (
     "yearsOfExperience" TEXT NOT NULL,
     "location" TEXT NOT NULL,
     "willingToRelocate" BOOLEAN NOT NULL,
+    "playstyle" TEXT NOT NULL,
+    "gamingExperience" TEXT[],
+    "games" JSONB NOT NULL,
+    "gameUsernames" JSONB NOT NULL,
     "bio" TEXT,
     "about" TEXT,
     "accountId" INTEGER NOT NULL,
+    "rosterAccountIds" INTEGER[],
+    "recommendationStatistics" JSONB NOT NULL,
 
     CONSTRAINT "Player_pkey" PRIMARY KEY ("playerId")
 );
@@ -34,10 +40,14 @@ CREATE TABLE "Team" (
     "teamId" SERIAL NOT NULL,
     "name" TEXT NOT NULL,
     "location" TEXT NOT NULL,
+    "rosterAccountIds" INTEGER[],
     "currentlyHiring" BOOLEAN NOT NULL,
-    "yearEstablished" TEXT NOT NULL,
+    "desiredPlaystyle" TEXT[],
+    "supportedGames" TEXT[],
+    "desiredSkillLevel" TEXT NOT NULL,
     "description" TEXT,
     "overview" TEXT,
+    "recommendationHistory" JSONB NOT NULL,
     "accountId" INTEGER NOT NULL,
 
     CONSTRAINT "Team_pkey" PRIMARY KEY ("teamId")
@@ -52,6 +62,31 @@ CREATE TABLE "Application" (
     "status" "ApplicationStatus" NOT NULL DEFAULT 'pending',
 
     CONSTRAINT "Application_pkey" PRIMARY KEY ("applicationId")
+);
+
+-- CreateTable
+CREATE TABLE "Tournaments" (
+    "id" SERIAL NOT NULL,
+    "tournamentIds" INTEGER[],
+
+    CONSTRAINT "Tournaments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Tournament" (
+    "tournamentId" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "rounds" JSONB NOT NULL,
+    "minimumParticipants" INTEGER NOT NULL,
+    "currentRound" INTEGER NOT NULL DEFAULT 1,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "creatorAccountId" INTEGER NOT NULL,
+    "allTournamentsId" INTEGER NOT NULL,
+    "isActive" BOOLEAN NOT NULL,
+    "allParticipants" JSONB NOT NULL,
+    "participantsAdvancedToNextRound" JSONB NOT NULL,
+
+    CONSTRAINT "Tournament_pkey" PRIMARY KEY ("tournamentId")
 );
 
 -- CreateIndex
@@ -77,3 +112,6 @@ ALTER TABLE "Application" ADD CONSTRAINT "Application_playerAccountId_fkey" FORE
 
 -- AddForeignKey
 ALTER TABLE "Application" ADD CONSTRAINT "Application_teamAccountId_fkey" FOREIGN KEY ("teamAccountId") REFERENCES "Account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Tournament" ADD CONSTRAINT "Tournament_allTournamentsId_fkey" FOREIGN KEY ("allTournamentsId") REFERENCES "Tournaments"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/recommendation/algorithm.js
+++ b/backend/recommendation/algorithm.js
@@ -5,6 +5,7 @@ import {
 } from "./recommendationUtils.js"
 import { translateExperience } from "../ServerUtils.js"
 
+const NUMBER_OF_RECOMMENDATIONS = 10
 const CollaborativeFilteringWeight = {
 	LOCATION_WEIGHT: 0.4,
 	SKILL_LEVEL_WEIGHT: 0.3,
@@ -138,5 +139,6 @@ export async function getAllRecommendations(playerData, allTeams) {
 		recommendations.push({ team: teamData, score: finalScore })
 	}
 
-	return recommendations
+	const topTenRecommendations = recommendations.slice(0, NUMBER_OF_RECOMMENDATIONS)
+	return topTenRecommendations
 }

--- a/backend/recommendation/algorithm.js
+++ b/backend/recommendation/algorithm.js
@@ -1,6 +1,7 @@
 import {
 	getRejectedTeamAttributesFrequency,
 	getTeamRosterAttributesFrequency,
+	getEligibleTeams
 } from "./recommendationUtils.js"
 import { translateExperience } from "../ServerUtils.js"
 
@@ -112,8 +113,9 @@ async function getAverageDeclinedPlayerScore(teamData, playerData) {
 
 export async function getAllRecommendations(playerData, allTeams) {
 	const recommendations = []
+	const eligibleTeams = getEligibleTeams(playerData, allTeams)
 
-	for (const teamData of allTeams) {
+	for (const teamData of eligibleTeams) {
 		let rosterSimilarityScore = await getRosterSimilarityScore(teamData, playerData)
 		rosterSimilarityScore *= FinalRecommendationScoreWeight.ROSTER_SIMILARITY_WEIGHT
 

--- a/backend/recommendation/recommendationApiUtils.js
+++ b/backend/recommendation/recommendationApiUtils.js
@@ -118,6 +118,11 @@ export function userInteractedWithRecommendation(
 	teamData,
 	recommendationStatus
 ) {
+	const playerInteractions = playerData.recommendationStatistics.interactions
+	if (!playerInteractions[teamData.accountId]) {
+		playerInteractions[teamData.accountId] = getDefaultInteractions()
+	}
+	
 	if (recommendationStatus == RecommendationStatus.INTERESTED) {
 		return acceptedRecommendation(playerData, teamData)
 	} else {

--- a/backend/recommendation/recommendationApiUtils.js
+++ b/backend/recommendation/recommendationApiUtils.js
@@ -103,7 +103,7 @@ export function getDefaultInteractions() {
 	return {
 		profileVisits: 0,
 		declinedRecommendation: false,
-		memberOfTeam: false,
+		acceptedRecommendation: false,
 		rejectedFromTeam: false,
 	}
 }
@@ -188,5 +188,10 @@ function acceptedRecommendation(playerData, teamData) {
 		TeamAcceptanceWeight,
 		StatusModifier.ACCEPTED
 	)
+
+	playerData.recommendationStatistics.interactions[
+		teamData.accountId
+	].acceptedRecommendation = true
+
 	return updatedPlayerData
 }

--- a/backend/recommendation/recommendationUtils.js
+++ b/backend/recommendation/recommendationUtils.js
@@ -59,12 +59,21 @@ export async function getTeamRosterAttributesFrequency(teamData) {
 export function getEligibleTeams(playerData, allTeams) {
 	const eligibleTeams = []
 	for (const team of allTeams) {
+		const playerInteractionsWithTeam =
+			playerData.recommendationHistory.interactions[team.teamId]
+
 		if (team.currentlyHiring == false) continue
 		if (team.rosterAccountIds.includes(playerData.accountId)) continue
 		if (playerData.willingToRelocate == false && team.location != playerData.location)
 			continue
+		if (playerInteractionsWithTeam != null) {
+			if (playerInteractionsWithTeam.declinedRecommendation == true) continue
+			if (playerInteractionsWithTeam.acceptedRecommendation == true) continue
+			if (playerInteractionsWithTeam.rejectedFromTeam == true) continue
+		}
+
 		eligibleTeams.push(team)
 	}
-	
+
 	return eligibleTeams
 }

--- a/backend/recommendation/recommendationUtils.js
+++ b/backend/recommendation/recommendationUtils.js
@@ -55,3 +55,16 @@ export async function getTeamRosterAttributesFrequency(teamData) {
 		teamData.rosterAccountIds.length
 	)
 }
+
+export function getEligibleTeams(playerData, allTeams) {
+	const eligibleTeams = []
+	for (const team of allTeams) {
+		if (team.currentlyHiring == false) continue
+		if (team.rosterAccountIds.includes(playerData.accountId)) continue
+		if (playerData.willingToRelocate == false && team.location != playerData.location)
+			continue
+		eligibleTeams.push(team)
+	}
+	
+	return eligibleTeams
+}

--- a/backend/recommendation/recommendationUtils.js
+++ b/backend/recommendation/recommendationUtils.js
@@ -58,18 +58,20 @@ export async function getTeamRosterAttributesFrequency(teamData) {
 
 export function getEligibleTeams(playerData, allTeams) {
 	const eligibleTeams = []
+	
 	for (const team of allTeams) {
-		const playerInteractionsWithTeam =
-			playerData.recommendationHistory.interactions[team.teamId]
+		const playerInteractions = playerData.recommendationStatistics.interactions
 
 		if (team.currentlyHiring == false) continue
 		if (team.rosterAccountIds.includes(playerData.accountId)) continue
 		if (playerData.willingToRelocate == false && team.location != playerData.location)
 			continue
-		if (playerInteractionsWithTeam != null) {
-			if (playerInteractionsWithTeam.declinedRecommendation == true) continue
-			if (playerInteractionsWithTeam.acceptedRecommendation == true) continue
-			if (playerInteractionsWithTeam.rejectedFromTeam == true) continue
+		if (playerInteractions[team.accountId] != null) {
+			if (playerInteractions[team.accountId].declinedRecommendation == true)
+				continue
+			if (playerInteractions[team.accountId].acceptedRecommendation == true)
+				continue
+			if (playerInteractions[team.accountId].rejectedFromTeam == true) continue
 		}
 
 		eligibleTeams.push(team)

--- a/frontend/src/components/PlayerProfile/PlayerProfile.jsx
+++ b/frontend/src/components/PlayerProfile/PlayerProfile.jsx
@@ -23,7 +23,7 @@ export default function PlayerProfile({ isLoading, accountData, setIsLoading }) 
 	const [bio, setBio] = useState(accountData.bio || DEFAULT_PROFILE_INFO)
 	const [about, setAbout] = useState(accountData.about || DEFAULT_PROFILE_INFO)
 	const { id } = useParams()
-
+	
 	return (
 		<>
 			<Navbar />


### PR DESCRIPTION
## Description
This PR adds team eligibility filtering to the recommendation algorithm. Teams will not be eligible to be recommended if their attributes conflict with the users. Examples include
- The team's location is different from the user and the user isn't willing to relocate
- The team isn't currently hiring
- The player has already accepted or rejected that recommendation
- The player has already applied to the team
- The player is already apart of that team's roster

This PR also updates the user's interaction data associated with teams after accepting/rejecting their recommendation

## Video Preview
[Viewing recommendations](https://pxl.cl/7Mx0V)